### PR TITLE
docs(tapi/caching): fix 'handleRequest' -> 'handleTapiRequest' in service-worker example

### DIFF
--- a/website/src/content/docs/tapi/reference/caching.md
+++ b/website/src/content/docs/tapi/reference/caching.md
@@ -73,7 +73,7 @@ import { handleTapiRequest } from '@farbenmeer/tapi/worker';
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   if (url.host === process.env.BASE_URL && /\/api/.test(url.pathname)) {
-    event.respondWith(handleRequest(process.env.BUILD_ID, event.request));
+    event.respondWith(handleTapiRequest(process.env.BUILD_ID, event.request));
   }
 });
 ```


### PR DESCRIPTION
## Summary

Per #244, the caching strategies page imports \`handleTapiRequest\` but the \`event.respondWith()\` call used \`handleRequest\`, so copy-pasting the example fails with \`ReferenceError: handleRequest is not defined\`. The service-worker guide at \`guides/service-worker.md\` already uses \`handleTapiRequest\` on both sides, so this aligns the reference doc with it.

Closes #244

## Testing

Docs-only change; one-line fix. Other files were grep-verified.