### PR TITLE
fix: use handleTapiRequest consistently in caching docs

### DIFF
--- a/website/src/content/docs/tapi/reference/caching.md
+++ b/website/src/content/docs/tapi/reference/caching.md
@@ -73,7 +73,7 @@ import { handleTapiRequest } from '@farbenmeer/tapi/worker';
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   if (url.host === process.env.BASE_URL && /\/api/.test(url.pathname)) {
-    event.respondWith(handleRequest(process.env.BUILD_ID, event.request));
+    event.respondWith(handleTapiRequest(process.env.BUILD_ID, event.request));
   }
 });
 ```


### PR DESCRIPTION
The code example on the caching strategies page imported `handleTapiRequest` but called `handleRequest`. This fixes the inconsistency by using `handleTapiRequest` in the event handler to match the import.

Closes #244

Generated with [Claude Code](https://claude.ai/code)