### PR TITLE
docs(tapi): add reference pages for invalidation stream handler

### DIFF
--- a/website/src/content/docs/tapi/reference/listenForInvalidations.md
+++ b/website/src/content/docs/tapi/reference/listenForInvalidations.md
@@ -1,0 +1,89 @@
+---
+title: listenForInvalidations
+---
+
+`listenForInvalidations` connects a service worker to the server's invalidation stream. When the server invalidates cache tags, the service worker receives them and immediately purges matching cached responses, then notifies all open clients to refetch.
+
+## Usage
+
+Call `listenForInvalidations` once at the top level of your service worker file, outside of any event listener:
+
+```ts
+// service-worker.ts
+import { handleTapiRequest, listenForInvalidations } from "@farbenmeer/tapi/worker";
+
+declare const self: ServiceWorkerGlobalScope;
+
+const BUILD_ID = "__BUILD_ID__"; // replaced at build time
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith("/api")) {
+    event.respondWith(handleTapiRequest(BUILD_ID, event.request));
+  }
+});
+
+listenForInvalidations({
+  url: "/__tapi/invalidations",
+  buildId: BUILD_ID,
+});
+```
+
+The `url` must point to a route handled by [`streamRevalidatedTags`](/tapi/reference/streamrevalidatedtags) on the server. The `buildId` must match the value passed to `streamRevalidatedTags`.
+
+## Signature
+
+```ts
+function listenForInvalidations(options: Options): Promise<void>
+```
+
+Returns a `Promise` that resolves once the connection is established (or fails after exhausting retries). Reconnection after a network drop is handled automatically.
+
+## Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `url` | `string` | The URL of the server-side invalidation stream endpoint. You can use the built-in `INVALIDATIONS_ROUTE` constant (`/__tapi/invalidations`) or a custom path. |
+| `buildId` | `string` | A unique identifier for the current build. Must match the `buildId` passed to `streamRevalidatedTags` on the server. |
+
+## Behavior
+
+### On connection
+
+When `listenForInvalidations` successfully opens the stream, it:
+
+1. Marks **all** currently cached entries as expired.
+2. Posts an `TAPI_INVALIDATE_TAGS` message to all open clients with the full list of expired tags, triggering an immediate refetch.
+
+This ensures that any data cached while the service worker was offline or during a previous deployment is immediately refreshed.
+
+### While connected
+
+For each line received from the stream:
+
+1. Parses the space-separated tag names.
+2. Invalidates matching cache entries via `invalidateTags`.
+3. Posts a `TAPI_INVALIDATE_TAGS` message to all open clients so they refetch affected data.
+
+### On network disconnect
+
+If the stream closes due to a network error, `listenForInvalidations` waits 5 seconds and then reconnects automatically.
+
+### On build ID mismatch
+
+If the `X-TAPI-Build-Id` response header does not match `buildId`, the service worker calls `self.registration.update()` to install the latest version and clears the stale cache.
+
+### On non-stream response
+
+If the server returns an unexpected response (wrong `Content-Type`, non-2xx status), the service worker unregisters itself and clears its cache to avoid serving stale data indefinitely.
+
+### Retry logic
+
+If the initial fetch fails (e.g., server not yet reachable), `listenForInvalidations` retries up to 1000 times using exponential backoff (starting at 500 ms).
+
+## Related
+
+- [`streamRevalidatedTags`](/tapi/reference/streamrevalidatedtags) — the server-side function that produces the invalidation stream.
+- [`handleTapiRequest`](/tapi/guides/service-worker) — the service worker fetch handler that caches TApi responses.
+- [Caching Strategies](/tapi/reference/caching) — overview of how all cache layers work together.
+- [Service Worker Setup](/tapi/guides/service-worker) — step-by-step guide for setting up the service worker.

--- a/website/src/content/docs/tapi/reference/streamRevalidatedTags.md
+++ b/website/src/content/docs/tapi/reference/streamRevalidatedTags.md
@@ -1,0 +1,70 @@
+---
+title: streamRevalidatedTags
+---
+
+`streamRevalidatedTags` creates a long-polling HTTP response that streams invalidated cache tags to connected service workers. This is the server-side half of TApi's tag-based revalidation system.
+
+## Usage
+
+Register a dedicated route in your server that calls `streamRevalidatedTags` and returns the result. The service worker will connect to this route on startup and receive tag invalidations in real time.
+
+```ts
+import { streamRevalidatedTags } from "@farbenmeer/tapi/server";
+import { api } from "./api";
+
+// Next.js App Router example
+export const GET = () =>
+  streamRevalidatedTags({ cache: api.cache, buildId: process.env.BUILD_ID! });
+```
+
+The route path must match the `url` passed to [`listenForInvalidations`](/tapi/reference/listenforinvalidations) in your service worker. You can use the built-in `INVALIDATIONS_ROUTE` constant (`/__tapi/invalidations`) or define your own.
+
+```ts
+import {
+  streamRevalidatedTags,
+  INVALIDATIONS_ROUTE,
+} from "@farbenmeer/tapi/server";
+import { api } from "./api";
+
+// INVALIDATIONS_ROUTE === "/__tapi/invalidations"
+export const GET = () =>
+  streamRevalidatedTags({ cache: api.cache, buildId: process.env.BUILD_ID! });
+```
+
+## Signature
+
+```ts
+function streamRevalidatedTags(options: Options): Response
+```
+
+Returns a streaming `Response` with `Content-Type: text/tapi-tags`. The response body is a newline-delimited stream of space-separated tag names. A keepalive newline is sent every 10 seconds to keep the connection alive.
+
+## Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `cache` | `Cache` | The cache/pub-sub instance to subscribe to. Use `api.cache` to share the same instance as your `defineApi` call. |
+| `buildId` | `string` | A unique identifier for the current build. The service worker uses this to detect when it needs to reload. Typically set to a Git commit SHA or build timestamp via an environment variable. |
+
+## Response Headers
+
+The response includes the following headers:
+
+| Header | Value | Description |
+| --- | --- | --- |
+| `Content-Type` | `text/tapi-tags` | Signals to the service worker that this is a TApi invalidation stream. |
+| `X-TAPI-Build-Id` | `buildId` | The build ID passed in options. Used by the service worker to detect stale builds. |
+| `Set-Cookie` | `__tapi-session=<uuid>` | A session cookie that prevents the server from echoing a client's own mutations back to that same client. |
+
+## Behavior
+
+- **Session deduplication**: Each connected client receives a unique session ID via a cookie. When the server invalidates tags, it skips notifying the client whose mutation triggered the invalidation (the `meta.clientId` passed to `cache.delete`).
+- **Keepalive**: A blank newline is sent every 10 seconds to prevent proxies and load balancers from closing idle connections.
+- **Build ID mismatch**: If the service worker connects and the `X-TAPI-Build-Id` header does not match its own `buildId`, the service worker will update itself.
+
+## Related
+
+- [`listenForInvalidations`](/tapi/reference/listenforinvalidations) — the service worker counterpart that consumes this stream.
+- [`defineApi`](/tapi/reference/defineapi) — exposes `api.cache` used in the `cache` option.
+- [`PubSub`](/tapi/reference/caching#server-side-cache) — the default in-process pub-sub implementation.
+- [Caching Strategies](/tapi/reference/caching) — overview of how all cache layers work together.


### PR DESCRIPTION
Adds dedicated reference docs for `streamRevalidatedTags` (server) and `listenForInvalidations` (worker), covering signatures, options, response headers, and runtime behavior.

Closes #243

Generated with [Claude Code](https://claude.ai/code)