### PR TITLE
vite-plugin-tapi: emit client + server bundles

### DIFF
--- a/.changeset/warm-fans-melt.md
+++ b/.changeset/warm-fans-melt.md
@@ -1,0 +1,5 @@
+---
+"@farbenmeer/vite-plugin-tapi": patch
+---
+
+vite-plugin-tapi: emit client + server bundles

--- a/packages/3-vite-plugin-tapi/src/index.ts
+++ b/packages/3-vite-plugin-tapi/src/index.ts
@@ -64,13 +64,17 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
         },
         builder: {
           async buildApp(builder) {
+            const ssr = builder.environments.ssr;
+            if (!ssr) throw new Error("[vite-plugin-tapi] missing ssr environment");
+
             const hasClient = fs.existsSync(
               path.join(builder.config.root, "index.html"),
             );
             if (hasClient) {
-              await builder.build(builder.environments.client);
+              const client = builder.environments.client;
+              if (client) await builder.build(client);
             }
-            await builder.build(builder.environments.ssr);
+            await builder.build(ssr);
           },
         },
       };

--- a/packages/3-vite-plugin-tapi/src/index.ts
+++ b/packages/3-vite-plugin-tapi/src/index.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Plugin, ViteDevServer } from "vite";
 import { serve, type ServerHandler, type Server } from "srvx";
@@ -42,21 +43,36 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
     config(_userConfig, env) {
       if (env.command !== "build") return;
       return {
-        build: {
-          ssr: true,
-          outDir: "dist",
-          rolldownOptions: {
-            input: VIRTUAL_ID,
-            output: {
-              format: "esm",
-              entryFileNames: "server.mjs",
+        environments: {
+          ssr: {
+            build: {
+              // Client build runs first and empties dist; ssr appends server.mjs.
+              emptyOutDir: false,
+              rolldownOptions: {
+                input: VIRTUAL_ID,
+                output: {
+                  format: "esm",
+                  entryFileNames: "server.mjs",
+                },
+                ...(standalone
+                  ? {}
+                  : { external: ["srvx", /^@farbenmeer\/tapi(\/.*)?$/] }),
+              },
             },
-            ...(standalone
-              ? {}
-              : { external: ["srvx", /^@farbenmeer\/tapi(\/.*)?$/] }),
+            resolve: standalone ? { noExternal: true } : undefined,
           },
         },
-        ssr: standalone ? { noExternal: true } : undefined,
+        builder: {
+          async buildApp(builder) {
+            const hasClient = fs.existsSync(
+              path.join(builder.config.root, "index.html"),
+            );
+            if (hasClient) {
+              await builder.build(builder.environments.client);
+            }
+            await builder.build(builder.environments.ssr);
+          },
+        },
       };
     },
 
@@ -130,7 +146,7 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
         },
       });
       await server.ready();
-      console.info(`[vite-plugin-tapi] dev server on ${server.url}`);
+      console.info(`[vite-plugin-tapi] api server on ${server.url}`);
 
       const onChange = async () => {
         vite.moduleGraph.invalidateAll();


### PR DESCRIPTION
- Replace the global `build.ssr = true` override with a dedicated `ssr` environment plus a `builder.buildApp` that runs `client` then `ssr`. Apps now get the standard Vite client build (`index.html`, `assets/*`) alongside `dist/server.mjs`.
- Skip the client step when no `index.html` exists in the project root, so api-only setups like `examples/vite-plugin-tapi-demo` keep working.
- Rename the dev-server log to `api server on …` — it advertises the srvx api server, not Vite's dev server on 5173.

Motivated by `farbenmeer/partitur`, where `pnpm build` previously produced only `dist/server.mjs` (~600 bytes) and silently dropped the entire client bundle.