### PR TITLE
router: fix racy assertion in use-params route-switch test

### DIFF
--- a/packages/1-router/src/use-params.test.tsx
+++ b/packages/1-router/src/use-params.test.tsx
@@ -365,12 +365,12 @@ describe("useParams", () => {
 
       await screen.getByText("Go to post").click();
 
-      expect(
-        screen.container.querySelector('[data-testid="param-id"]')
-      ).toBeNull();
       await expect
         .element(screen.getByTestId("param-slug"), { timeout: 100 })
         .toHaveTextContent("hello-world");
+      expect(
+        screen.container.querySelector('[data-testid="param-id"]')
+      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
- The "switching between routes with different parameters" test in `use-params.test.tsx` ran a synchronous `querySelector` for the *old* `param-id` immediately after `click()`, before any polling waited for React to commit the route change. Fast machines won the race; CI lost it.
- Swap the two post-click assertions: poll for the new `param-slug` to appear first, then assert `param-id` is gone. Both routes toggle in the same commit, so the absence check is deterministic once the new testid is in the DOM.