### PR TITLE
vite-plugin-tapi: extract production runtime into a real module

### DIFF
--- a/packages/3-vite-plugin-tapi/package.json
+++ b/packages/3-vite-plugin-tapi/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
     }
   },
   "scripts": {

--- a/packages/3-vite-plugin-tapi/src/index.ts
+++ b/packages/3-vite-plugin-tapi/src/index.ts
@@ -93,18 +93,15 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
 
     load(id) {
       if (id !== RESOLVED_VIRTUAL_ID) return null;
-      const entryImport = JSON.stringify(resolvedEntry);
       return [
-        `import { serve } from "srvx";`,
-        `import { createRequestHandler } from "@farbenmeer/tapi/server";`,
-        `import { api } from ${entryImport};`,
+        `import { startServer } from "@farbenmeer/vite-plugin-tapi/runtime";`,
+        `import { api } from ${JSON.stringify(resolvedEntry)};`,
         ``,
-        `const fetch = createRequestHandler(api, { basePath: ${JSON.stringify(basePath)} });`,
-        `const port = Number(process.env.PORT) || ${options.port ?? 3000};`,
-        ``,
-        `const server = serve({ port, fetch });`,
-        `await server.ready();`,
-        `console.info(\`[tapi] server listening on \${server.url}\`);`,
+        `await startServer({`,
+        `  api,`,
+        `  basePath: ${JSON.stringify(basePath)},`,
+        `  port: Number(process.env.PORT) || ${options.port ?? 3000},`,
+        `});`,
         ``,
       ].join("\n");
     },

--- a/packages/3-vite-plugin-tapi/src/runtime.ts
+++ b/packages/3-vite-plugin-tapi/src/runtime.ts
@@ -1,0 +1,23 @@
+import { serve } from "srvx";
+import { createRequestHandler } from "@farbenmeer/tapi/server";
+
+type Api = Parameters<typeof createRequestHandler>[0];
+
+export interface StartServerOptions {
+  api: Api;
+  basePath: string;
+  port: number;
+}
+
+/**
+ * Production runtime for the bundled `server.mjs`. Imported by the
+ * plugin's virtual entry — not part of the user-facing API surface.
+ *
+ * @internal
+ */
+export async function startServer(opts: StartServerOptions): Promise<void> {
+  const fetch = createRequestHandler(opts.api, { basePath: opts.basePath });
+  const server = serve({ port: opts.port, fetch });
+  await server.ready();
+  console.info(`[tapi] server listening on ${server.url}`);
+}


### PR DESCRIPTION
Stacked on top of #264. Independent of #266 — either can land first.

- Move the production runtime out of the virtual `load()` string and into `src/runtime.ts`. The virtual module shrinks to seven lines of glue that import `startServer` from `@farbenmeer/vite-plugin-tapi/runtime`.
- Add a `"./runtime"` subpath to the package's `exports` (marked `@internal`).
- IDE now type-checks, autocompletes, and syntax-highlights the actual server logic; nothing changes at build- or run-time. Rolldown still inlines the runtime into the consumer's `server.mjs` (no new runtime dep).