### PR TITLE
vite-plugin-tapi: auto-load .env into process.env in dev

### DIFF
--- a/.changeset/dev-env-loading.md
+++ b/.changeset/dev-env-loading.md
@@ -1,0 +1,9 @@
+---
+"@farbenmeer/vite-plugin-tapi": minor
+"@farbenmeer/bunny": patch
+"@farbenmeer/vite-plugin-tapi-example-demo": patch
+---
+
+vite-plugin-tapi: auto-load .env into process.env in dev
+
+Mirror Vite's `loadEnv` result into `process.env` at the top of `configureServer` so server-side libraries (BetterAuth, DB clients, OAuth secrets) see their secrets in dev without any changes to user code. Shell vars keep precedence over `.env` values. Production is unchanged.

--- a/examples/vite-plugin-tapi-demo/.env.development
+++ b/examples/vite-plugin-tapi-demo/.env.development
@@ -1,0 +1,2 @@
+FOO=fromEnv
+BAR=fromEnv

--- a/examples/vite-plugin-tapi-demo/e2e/dev/basic.spec.ts
+++ b/examples/vite-plugin-tapi-demo/e2e/dev/basic.spec.ts
@@ -25,3 +25,14 @@ test("api returns json", async ({ request }) => {
   expect(res.status()).toBe(200);
   expect(await res.json()).toEqual({ greeting: "hello, api" });
 });
+
+test("server sees .env vars; shell env takes precedence", async ({
+  request,
+}) => {
+  // .env.development sets FOO=fromEnv, BAR=fromEnv.
+  // playwright.config.ts overrides FOO=fromShell in the dev webServer env.
+  // Expectation: shell wins for FOO, .env supplies BAR.
+  const res = await request.get("/whoami");
+  expect(res.status()).toBe(200);
+  expect(await res.json()).toEqual({ foo: "fromShell", bar: "fromEnv" });
+});

--- a/examples/vite-plugin-tapi-demo/playwright.config.ts
+++ b/examples/vite-plugin-tapi-demo/playwright.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
   webServer: [
     {
       command: "pnpm dev",
-      env: { PORT: "3200" },
+      // FOO is also set in .env.development; the shell value must win.
+      env: { PORT: "3200", FOO: "fromShell" },
       port: 3200,
       reuseExistingServer: !process.env.CI,
       stdout: "pipe",

--- a/examples/vite-plugin-tapi-demo/src/api.ts
+++ b/examples/vite-plugin-tapi-demo/src/api.ts
@@ -53,4 +53,12 @@ export const api = defineApi()
         return TResponse.json({ greeting: `hello, ${name}` });
       },
     ),
+  })
+  .route("/whoami", {
+    GET: defineHandler({ authorize: () => true }, async () => {
+      return TResponse.json({
+        foo: process.env.FOO ?? null,
+        bar: process.env.BAR ?? null,
+      });
+    }),
   });

--- a/packages/3-bunny/recipes/better-auth.md
+++ b/packages/3-bunny/recipes/better-auth.md
@@ -8,6 +8,16 @@ To setup [better-auth](https://better-auth.com/) with bunny:
 pnpm add better-auth
 ```
 
+* Put your secrets in `.env` at the project root. With `@farbenmeer/vite-plugin-tapi` they are auto-loaded into `process.env` in dev; bunny apps typically rely on the same convention.
+
+```
+BETTER_AUTH_SECRET=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+For production deploys, set the same vars via your runtime (Docker, systemd, PaaS) — `.env` is a dev convenience, not a deploy artifact.
+
 * Create your better-auth configuration file at `src/lib/auth.ts` and follow the better-auth [documentation](https://better-auth.com/docs) to configure it.
 
 * Create your better-auth request handler at `src/api/auth.ts` as follows:

--- a/packages/3-vite-plugin-tapi/README.md
+++ b/packages/3-vite-plugin-tapi/README.md
@@ -1,0 +1,64 @@
+# @farbenmeer/vite-plugin-tapi
+
+Vite plugin that runs a TApi server alongside Vite's dev server and bundles a production server entry on `vite build`.
+
+## Install
+
+```bash
+pnpm add -D @farbenmeer/vite-plugin-tapi
+```
+
+Peer-deps: `vite ^8`, `@farbenmeer/tapi`.
+
+## Usage
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import tapi from "@farbenmeer/vite-plugin-tapi";
+
+export default defineConfig({
+  plugins: [tapi()],
+});
+```
+
+The plugin looks for `src/api.ts` (override via `entry`), expects an exported `api` (an `ApiDefinition`), and serves it on `/api/*` (override via `basePath`).
+
+## Options
+
+| Option       | Default       | Description                                                                       |
+| ------------ | ------------- | --------------------------------------------------------------------------------- |
+| `entry`      | `"src/api.ts"`| Path to the module exporting `api`. Resolved against the Vite root.               |
+| `basePath`   | `"/api"`      | Mount path for the api handler. Empty string mounts at root.                      |
+| `port`       | `3000`        | Port for the api server. Falls back to `PORT` env var.                            |
+| `standalone` | `false`       | If `true`, the production bundle inlines `srvx` and `@farbenmeer/tapi`.           |
+
+## Environment variables
+
+### Dev (`pnpm dev`)
+
+The plugin loads `.env`, `.env.local`, `.env.<mode>`, and `.env.<mode>.local` via Vite's `loadEnv` and mirrors every key into `process.env` before the api module is loaded. Existing `process.env` values keep precedence, so shell vars override `.env` files.
+
+```
+.env                     # all envs
+.env.local               # all envs, ignored by git
+.env.development         # dev only
+.env.development.local   # dev only, ignored by git
+```
+
+This covers server-side libraries that read `process.env.X` directly (BetterAuth, DB clients, OAuth secrets). Vite's `import.meta.env` injection still applies to client code.
+
+### Production (`node dist/server.mjs`)
+
+The built server does **not** load `.env` files. In production, env vars come from the runtime — Docker, systemd, or your PaaS. If you want `.env` support locally for production smoke tests, opt in via Node's built-in flag:
+
+```jsonc
+// package.json
+"scripts": {
+  "start": "node --env-file-if-exists=.env dist/server.mjs"
+}
+```
+
+## Build output
+
+`vite build` emits `dist/server.mjs`. By default `srvx` and `@farbenmeer/tapi` are external; the consumer needs them installed at runtime. With `standalone: true` they are inlined and the output runs without `node_modules`.

--- a/packages/3-vite-plugin-tapi/src/index.ts
+++ b/packages/3-vite-plugin-tapi/src/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { Plugin, ViteDevServer } from "vite";
+import { loadEnv, type Plugin, type ViteDevServer } from "vite";
 import { serve, type ServerHandler, type Server } from "srvx";
 import { createRequestHandler } from "@farbenmeer/tapi/server";
 
@@ -90,6 +90,15 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
     },
 
     async configureServer(vite) {
+      // Vite injects .env values into `import.meta.env` for the client only;
+      // the api runs in this same Node process and reads `process.env`. Mirror
+      // every var (empty prefix, not just VITE_*) into process.env so server
+      // code sees secrets like BETTER_AUTH_SECRET. Existing process.env wins.
+      const env = loadEnv(vite.config.mode, vite.config.envDir, "");
+      for (const [k, v] of Object.entries(env)) {
+        if (process.env[k] === undefined) process.env[k] = v;
+      }
+
       const loadHandler = async () => {
         const mod = (await vite.ssrLoadModule(resolvedEntry)) as {
           api?: Parameters<typeof createRequestHandler>[0];


### PR DESCRIPTION
- Mirror Vite's `loadEnv` result into `process.env` at the top of `configureServer`, before the first `ssrLoadModule`. Empty prefix loads every var (not just `VITE_*`); existing `process.env` keeps precedence so shell vars stay authoritative. Server-side libs (BetterAuth, DB clients, OAuth secrets) now see their secrets in dev without changes to user code.
- Production build is unchanged — runtime env comes from Docker/systemd/PaaS. README documents `node --env-file-if-exists=.env dist/server.mjs` as the local opt-in.
- Demo: `.env.development` sets `FOO`/`BAR`, playwright overrides `FOO` via shell env, new `/whoami` route + e2e test verify both that `.env` loads *and* shell vars win.
- Adds a brief env-vars note to the BetterAuth recipe and a new plugin README documenting the env handling.