### PR TITLE
fix(workflow): widen DrizzleBetterSqliteAdapter schema generic to any

### DIFF
--- a/.changeset/twenty-dancers-brush.md
+++ b/.changeset/twenty-dancers-brush.md
@@ -1,0 +1,5 @@
+---
+"@farbenmeer/workflow": patch
+---
+
+fix(workflow): widen DrizzleBetterSqliteAdapter schema generic to any

--- a/packages/1-workflow/src/adapter-drizzle-better-sqlite/adapter.ts
+++ b/packages/1-workflow/src/adapter-drizzle-better-sqlite/adapter.ts
@@ -2,7 +2,7 @@ import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { SqliteAdapter } from "../adapter-sqlite/adapter-sqlite";
 
 export class DrizzleBetterSqliteAdapter extends SqliteAdapter {
-  constructor(drizzleDb: BetterSQLite3Database) {
+  constructor(drizzleDb: BetterSQLite3Database<any>) {
     super((drizzleDb as any).$client);
   }
 }


### PR DESCRIPTION
BetterSQLite3Database defaulted to Record<string, never>, rejecting any db instance with a non-empty schema. Using <any> accepts all schema shapes.

Closes #310

Generated with [Claude Code](https://claude.ai/code)