### PR TITLE
fix: notify new subscribers of already-resolved value in cache

### DIFF
--- a/.changeset/smart-mice-relax.md
+++ b/.changeset/smart-mice-relax.md
@@ -1,0 +1,5 @@
+---
+"@farbenmeer/tapi": patch
+---
+
+fix: notify new subscribers of already-resolved value in cache

--- a/packages/1-tapi/src/client/cache.ts
+++ b/packages/1-tapi/src/client/cache.ts
@@ -98,6 +98,10 @@ export class Cache {
           // so it doesn't miss the update.
           if (entry.next && entry.next !== observable) {
             callback(entry.next);
+          } else if (entry.current && entry.current.value !== observable) {
+            // A revalidation completed between cache.request() returning this
+            // observable and subscribe() being called — notify with the newer value.
+            callback(entry.current.value);
           }
 
           return () => {

--- a/packages/1-tapi/src/client/create-fetch-client.test.ts
+++ b/packages/1-tapi/src/client/create-fetch-client.test.ts
@@ -190,4 +190,21 @@ describe("createFetchClient", () => {
 
     expect(cb).not.toHaveBeenCalled();
   });
+
+  test("subscribe notifies of newer resolved value when revalidation completed before subscribe", async () => {
+    // Get the observable and wait for it to resolve so entry.current is set
+    const observable = client.books.get();
+    await observable;
+
+    // Trigger a revalidation and wait for it to fully complete so entry.current
+    // is updated to the new observable and entry.next is cleared
+    await client.books.revalidate();
+
+    // Now subscribe to the *original* observable — a new subscriber that missed
+    // the revalidation. The callback should fire immediately with the newer value.
+    const cb = vi.fn();
+    observable.subscribe(cb);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes #330

When a revalidation completes between `cache.request()` returning an observable and `subscribe()` being called on it, the new subscriber received no notification since `entry.next` was already cleared. Add an else-if branch in the subscribe handler to deliver the current resolved value immediately.

Generated with [Claude Code](https://claude.ai/code)