### PR TITLE
feat(workflow): async workflows via AsyncLocalStorage

### DIFF
--- a/.changeset/async-workflows.md
+++ b/.changeset/async-workflows.md
@@ -1,0 +1,17 @@
+---
+"@farbenmeer/workflow": minor
+---
+
+Workflows are now async functions backed by AsyncLocalStorage.
+
+Breaking changes:
+
+- `workflow(gen)` now requires `gen: (input) => Promise<void>` instead of a synchronous function.
+- `step(fn)` now returns `(input) => Promise<O>`. Use `await step()` inside workflows.
+- `rethrowSuspense` has been removed — `try/catch` around steps now works naturally because steps reject with real errors instead of throwing a sentinel for synchronous replay.
+- Steps with persisted errors (retry budget exhausted) now throw deterministically on replay instead of being re-executed.
+
+Improvements:
+
+- Parallel steps via `Promise.all([stepA(), stepB()])` are now supported. Step IDs include a per-run invocation counter so the same step can be called multiple times (in a loop or in parallel) without colliding.
+- Workflow code can `await` arbitrary helpers, not only steps.

--- a/.changeset/async-workflows.md
+++ b/.changeset/async-workflows.md
@@ -2,16 +2,4 @@
 "@farbenmeer/workflow": minor
 ---
 
-Workflows are now async functions backed by AsyncLocalStorage.
-
-Breaking changes:
-
-- `workflow(gen)` now requires `gen: (input) => Promise<void>` instead of a synchronous function.
-- `step(fn)` now returns `(input) => Promise<O>`. Use `await step()` inside workflows.
-- `rethrowSuspense` has been removed — `try/catch` around steps now works naturally because steps reject with real errors instead of throwing a sentinel for synchronous replay.
-- Steps with persisted errors (retry budget exhausted) now throw deterministically on replay instead of being re-executed.
-
-Improvements:
-
-- Parallel steps via `Promise.all([stepA(), stepB()])` are now supported. Step IDs include a per-run invocation counter so the same step can be called multiple times (in a loop or in parallel) without colliding.
-- Workflow code can `await` arbitrary helpers, not only steps.
+Workflows are now async functions backed by AsyncLocalStorage: `step()` returns a Promise, parallel steps via `Promise.all` are supported, and `rethrowSuspense` is removed.

--- a/packages/1-workflow/README.md
+++ b/packages/1-workflow/README.md
@@ -26,9 +26,9 @@ const sendEmail = step(async (email: string) => {
 const engine = startEngine({
   storage: new InMemoryAdapter(),
   workflows: {
-    onboardUser: workflow((userId: string) => {
-      const user = fetchUser(userId);
-      sendEmail(user.email);
+    onboardUser: workflow(async (userId: string) => {
+      const user = await fetchUser(userId);
+      await sendEmail(user.email);
     }),
   },
 });
@@ -39,12 +39,15 @@ await engine.onboardUser("user-123");
 
 ## How it works
 
-Workflows are synchronous generator-like functions. Each `step()` call either returns a cached result (if the step already succeeded) or throws internally to trigger execution. The engine catches this, runs the step's async function with retries, persists the result, then replays the workflow from the top. This means:
+Workflows are async functions. Each `step()` returns a Promise that either resolves to a cached result (if the step already succeeded in a previous attempt of this run) or runs the underlying async function with retries and persistence. The engine binds an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) run context around the workflow, so steps find their cached state through normal `await`s without needing any sync replay trickery. This means:
 
-- Steps that already succeeded are skipped on replay (their cached result is returned)
-- Failed steps are retried with exponential backoff
-- Workflows survive process restarts since all state is persisted
-- Multiple workers can poll for work using lease-based concurrency
+- Workflows can `await` anything, not just steps. Plain promises, helpers, libraries — all fine.
+- Failed steps are retried with exponential backoff; on retry exhaustion the step's promise rejects and your `try/catch` runs.
+- After a worker restart, the workflow function is replayed from the top. Steps that already succeeded resolve immediately with their cached result; steps that previously exhausted retries throw deterministically. Execution effectively resumes where it left off.
+- Parallel work composes naturally: `await Promise.all([stepA(input), stepB(input)])` runs both steps concurrently.
+- Multiple workers can poll for work using lease-based concurrency.
+
+**Determinism note.** Because workflows are replayed from the top, the workflow function itself should be deterministic — its branching and the order in which it invokes steps must be reproducible across replays. Put any non-determinism (timestamps, random numbers, external lookups) inside a `step()` so its result is persisted.
 
 ### Steps
 

--- a/packages/1-workflow/README.md
+++ b/packages/1-workflow/README.md
@@ -49,41 +49,141 @@ Workflows are async functions. Each `step()` returns a Promise that either resol
 
 **Determinism note.** Because workflows are replayed from the top, the workflow function itself should be deterministic — its branching and the order in which it invokes steps must be reproducible across replays. Put any non-determinism (timestamps, random numbers, external lookups) inside a `step()` so its result is persisted.
 
-### Steps
+## Usage
 
-Steps wrap async functions with retry logic and persistence.
+### Defining steps
+
+Steps wrap async functions with retry logic and persistence. The function you pass to `step()` is run when the step is awaited inside a workflow.
 
 ```ts
+import { step } from "@farbenmeer/workflow";
+
 // Default: 3 attempts, 250ms base backoff
-const myStep = step(async (input: string) => {
-  return await doSomething(input);
+const fetchUser = step(async (userId: string) => {
+  const res = await fetch(`/api/users/${userId}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
 });
 
 // Custom retry config
-const riskyStep = step({ attempts: 5, baseTimeout: 1000 }, async (input: string) => {
-  return await unreliableService(input);
+const callFlakyApi = step(
+  { attempts: 5, baseTimeout: 1000 },
+  async (input: string) => {
+    return await unreliableService(input);
+  },
+);
+```
+
+Retry backoff is exponential: `baseTimeout * 2^(attempt - 1)`. Step results must be JSON-serializable — they're persisted by the adapter and rehydrated on replay.
+
+A step must be called from inside a workflow. Calling one from regular application code throws.
+
+### Defining workflows
+
+A workflow is an `async` function. Use steps for anything you want persisted, retried, or to make resumable.
+
+```ts
+import { workflow } from "@farbenmeer/workflow";
+
+const onboardUser = workflow(async (userId: string) => {
+  const user = await fetchUser(userId);
+  await sendEmail(user.email);
 });
 ```
 
-Backoff is exponential: `baseTimeout * 2^(attempt - 1)`.
+Workflows take a single argument. Use an object if you need multiple parameters. The input is also persisted, so it must be JSON-serializable.
 
-To fail a step immediately without retries, throw a `FatalError`:
+### Starting the engine and triggering workflows
+
+Pass your workflows to `startEngine` along with a storage adapter. Each workflow name becomes a callable property on the returned engine.
+
+```ts
+import { startEngine } from "@farbenmeer/workflow";
+import { InMemoryAdapter } from "@farbenmeer/workflow/adapter-inmemory";
+
+const engine = startEngine({
+  storage: new InMemoryAdapter(),
+  workflows: { onboardUser },
+  // optional:
+  leaseDuration: 60, // seconds; how long a worker holds a run before it can be picked up by someone else
+  logger: console,   // any object with debug / info / warn / error / log
+});
+
+// Persist a run. The promise resolves once the run is queued; actual
+// execution happens in the engine's polling loop in the background.
+await engine.onboardUser("user-123");
+```
+
+### Parallel steps
+
+Because workflows are real async functions, you can fan out with `Promise.all`. Each step gets a stable, distinct ID even when the same step is invoked multiple times with the same input.
+
+```ts
+const greetEveryone = workflow(async (ids: string[]) => {
+  const users = await Promise.all(ids.map(fetchUser));
+  await Promise.all(users.map((u) => sendEmail(u.email)));
+});
+```
+
+### Error handling
+
+A failed step rejects with the underlying error after exhausting its retry budget. Wrap it in `try/catch` to recover inside the workflow.
+
+```ts
+const tryNotify = workflow(async (userId: string) => {
+  const user = await fetchUser(userId);
+  try {
+    await sendEmail(user.email);
+  } catch (err) {
+    await logFailedNotification({ userId, message: String(err) });
+  }
+});
+```
+
+If a step throws `FatalError`, retries are skipped and the error is surfaced immediately:
 
 ```ts
 import { FatalError } from "@farbenmeer/workflow";
 
-const validated = step(async (input: string) => {
+const validate = step(async (input: string) => {
   if (!isValid(input)) throw new FatalError("Invalid input");
   return process(input);
 });
 ```
 
-### Scheduled workflows
+If the workflow itself doesn't catch a thrown error, the engine marks the run as failed (its `error` field is populated) and moves on.
 
-Run workflows on a recurring interval:
+### Listing workflow runs
+
+```ts
+const page = await engine.listWorkflows({ pageSize: 20 });
+for (const run of page.workflows) {
+  console.log(run.workflowId, run.runId, run.error, run.finishedAt);
+}
+if (page.nextCursor) {
+  const next = await engine.listWorkflows({
+    pageSize: 20,
+    cursor: page.nextCursor,
+  });
+}
+```
+
+Each `WorkflowState` carries `workflowId`, `runId`, `input`, `error`, `startedAt`, `finishedAt`, and `leaseExpiredAt`.
+
+### Scheduling recurring runs
+
+Each workflow has a `.schedule(intervalSeconds, input)` method that re-triggers it on an interval. If a previous run for the same input completed recently, the next run is delayed until the interval has elapsed.
 
 ```ts
 engine.onboardUser.schedule(3600, "user-123"); // every hour
+```
+
+### Stopping the engine
+
+`engine.stop()` halts the polling loop. In-flight runs finish, but no new ones are picked up.
+
+```ts
+process.on("SIGINT", () => engine.stop());
 ```
 
 ## Storage adapters
@@ -163,7 +263,7 @@ Implement the `Adapter` interface:
 import type { Adapter } from "@farbenmeer/workflow";
 
 class MyAdapter implements Adapter {
-  getLastestRun(workflowId, input) { /* ... */ }
+  getLatestRun(workflowId, input) { /* ... */ }
   getNextWorkflow(leaseDuration) { /* ... */ }
   createWorkflow(input) { /* ... */ }
   failWorkflow(runId, error) { /* ... */ }

--- a/packages/1-workflow/src/adapter-drizzle-better-sqlite/adapter.test.ts
+++ b/packages/1-workflow/src/adapter-drizzle-better-sqlite/adapter.test.ts
@@ -56,9 +56,9 @@ describe("DrizzleBetterSqliteAdapter", () => {
     const engine = startEngine({
       storage: new DrizzleBetterSqliteAdapter(drizzleDb),
       workflows: {
-        test: workflow(function testWorkflow(who: string) {
-          const message = helloStep(who);
-          returnStep(message);
+        test: workflow(async function testWorkflow(who: string) {
+          const message = await helloStep(who);
+          await returnStep(message);
         }),
       },
     });

--- a/packages/1-workflow/src/adapter-postgres/adapter-postgres.test.ts
+++ b/packages/1-workflow/src/adapter-postgres/adapter-postgres.test.ts
@@ -98,9 +98,9 @@ describe("PostgresAdapter", () => {
     const engine = startEngine({
       storage: new PostgresAdapter(pg),
       workflows: {
-        test: workflow(function testWorkflow(who: string) {
-          const message = helloStep(who);
-          returnStep(message);
+        test: workflow(async function testWorkflow(who: string) {
+          const message = await helloStep(who);
+          await returnStep(message);
         }),
       },
     });

--- a/packages/1-workflow/src/adapter-sqlite/adapter-sqlite.test.ts
+++ b/packages/1-workflow/src/adapter-sqlite/adapter-sqlite.test.ts
@@ -94,9 +94,9 @@ describe("SqliteAdapter", () => {
     const engine = startEngine({
       storage: new SqliteAdapter(db),
       workflows: {
-        test: workflow(function testWorkflow(who: string) {
-          const message = helloStep(who);
-          returnStep(message);
+        test: workflow(async function testWorkflow(who: string) {
+          const message = await helloStep(who);
+          await returnStep(message);
         }),
       },
     });

--- a/packages/1-workflow/src/context.ts
+++ b/packages/1-workflow/src/context.ts
@@ -1,9 +1,12 @@
-import type { StepState } from "./adapter.js";
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Adapter, StepState } from "./adapter.js";
 
-export interface Context {
-  stepState: Map<string, StepState & { errorObject?: unknown }>;
+export interface RunContext {
+  runId: string;
+  storage: Adapter;
+  abortSignal: AbortSignal;
+  stepState: Map<string, StepState>;
+  callIndex: number;
 }
 
-export const context: Context = {
-  stepState: new Map(),
-};
+export const context = new AsyncLocalStorage<RunContext>();

--- a/packages/1-workflow/src/engine.test.ts
+++ b/packages/1-workflow/src/engine.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { InMemoryAdapter } from "./adapter-inmemory.js";
 import { startEngine } from "./engine.js";
-import { rethrowSuspense } from "./rethrow-suspense.js";
 import { step } from "./step.js";
 import { workflow } from "./workflow.js";
 
@@ -18,36 +17,34 @@ describe("engine", () => {
     const engine = startEngine({
       storage: new InMemoryAdapter(),
       workflows: {
-        fullWorkflow: workflow(() => {}),
+        fullWorkflow: workflow(async () => {}),
       },
       logger,
     });
 
     await engine.fullWorkflow();
+    engine.stop();
   });
 
   test("failure", async () => {
-    const fail = vi.fn(() => {
-      throw new Error("NEIN");
-    });
-    const failingStep = step<void, void>(fail);
+    const fail = vi.fn(() => Promise.reject(new Error("NEIN")));
+    const failingStep = step<void, void>({ baseTimeout: 1 }, fail);
 
-    const processError = vi.fn();
+    const processError = vi.fn(() => Promise.resolve());
     const processErrorStep = step<unknown, void>(processError);
 
     const engine = startEngine({
       storage: new InMemoryAdapter(),
       logger,
       workflows: {
-        failingWorkflow: workflow(() => {
-          failingStep();
+        failingWorkflow: workflow(async () => {
+          await failingStep();
         }),
-        finishingWorkflow: workflow(() => {
+        finishingWorkflow: workflow(async () => {
           try {
-            failingStep();
+            await failingStep();
           } catch (e) {
-            rethrowSuspense(e);
-            processErrorStep(e);
+            await processErrorStep(e);
           }
         }),
       },
@@ -57,10 +54,11 @@ describe("engine", () => {
 
     await vi.waitFor(async () => {
       const result = await engine.listWorkflows();
-      const [failingWorkflow] = result.workflows;
+      const failingWorkflow = result.workflows.find(
+        (w) => w.workflowId === "failingWorkflow",
+      );
 
-      expect(failingWorkflow.workflowId).toBe("failingWorkflow");
-      expect(failingWorkflow.error).toBe("NEIN");
+      expect(failingWorkflow?.error).toBe("NEIN");
       expect(fail).toHaveBeenCalledTimes(3);
       expect(logger.error).toHaveBeenCalledTimes(1);
     });
@@ -77,6 +75,78 @@ describe("engine", () => {
       expect(processError).toHaveBeenCalledWith(new Error("NEIN"));
       expect(finishingWorkflow?.error).toBeNull();
     });
+
+    engine.stop();
+  });
+
+  test("parallel steps via Promise.all", async () => {
+    const aFn = vi.fn(() => Promise.resolve("a"));
+    const bFn = vi.fn(() => Promise.resolve("b"));
+    const stepA = step<void, string>(aFn);
+    const stepB = step<void, string>(bFn);
+
+    const collected: string[] = [];
+    const collect = step<string[], void>(async (values) => {
+      collected.push(...values);
+    });
+
+    const storage = new InMemoryAdapter();
+    const engine = startEngine({
+      storage,
+      logger,
+      workflows: {
+        parallel: workflow(async () => {
+          const values = await Promise.all([stepA(), stepB()]);
+          await collect(values);
+        }),
+      },
+    });
+
+    await engine.parallel();
+
+    await vi.waitFor(async () => {
+      const result = await engine.listWorkflows();
+      const parallel = result.workflows.find(
+        (w) => w.workflowId === "parallel",
+      );
+      expect(parallel?.finishedAt).not.toBeNull();
+      expect(parallel?.error).toBeNull();
+    });
+
+    expect(aFn).toHaveBeenCalledTimes(1);
+    expect(bFn).toHaveBeenCalledTimes(1);
+    expect(collected).toEqual(["a", "b"]);
+
+    engine.stop();
+  });
+
+  test("same step called multiple times gets distinct ids", async () => {
+    const fn = vi.fn((input: number) => Promise.resolve(input * 2));
+    const double = step<number, number>(fn);
+
+    const results: number[] = [];
+    const engine = startEngine({
+      storage: new InMemoryAdapter(),
+      logger,
+      workflows: {
+        loop: workflow(async () => {
+          for (let i = 1; i <= 3; i++) {
+            results.push(await double(i));
+          }
+        }),
+      },
+    });
+
+    await engine.loop();
+
+    await vi.waitFor(async () => {
+      const page = await engine.listWorkflows();
+      const w = page.workflows.find((w) => w.workflowId === "loop");
+      expect(w?.finishedAt).not.toBeNull();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(results).toEqual([2, 4, 6]);
 
     engine.stop();
   });

--- a/packages/1-workflow/src/index.ts
+++ b/packages/1-workflow/src/index.ts
@@ -10,4 +10,3 @@ export type { Engine } from "./engine.js";
 export { workflow } from "./workflow.js";
 export { step } from "./step.js";
 export { FatalError } from "./fatal-error.js";
-export { rethrowSuspense } from "./rethrow-suspense.js";

--- a/packages/1-workflow/src/rethrow-suspense.ts
+++ b/packages/1-workflow/src/rethrow-suspense.ts
@@ -1,7 +1,0 @@
-import { Step } from "./step.js";
-
-export function rethrowSuspense(e: unknown) {
-  if (e instanceof Step) {
-    throw e;
-  }
-}

--- a/packages/1-workflow/src/step.test.ts
+++ b/packages/1-workflow/src/step.test.ts
@@ -1,125 +1,178 @@
 import crypto from "node:crypto";
 import { describe, expect, test, vi } from "vitest";
-import type { StepState } from "./adapter.js";
 import { InMemoryAdapter } from "./adapter-inmemory.js";
+import { context, type RunContext } from "./context.js";
 import { FatalError } from "./fatal-error.js";
 import { step } from "./step.js";
 
-describe("step", () => {
-  async function runStep(step: () => void, storage = new InMemoryAdapter()) {
+interface StepResult<T> {
+  ctx: RunContext;
+  result: T | undefined;
+  error: unknown;
+  storage: InMemoryAdapter;
+}
+
+async function withContext<T>(
+  body: () => Promise<T>,
+  storage: InMemoryAdapter = new InMemoryAdapter(),
+): Promise<StepResult<T>> {
+  const ctx: RunContext = {
+    runId: crypto.randomUUID(),
+    storage,
+    abortSignal: AbortSignal.timeout(5000),
+    stepState: new Map(),
+    callIndex: 0,
+  };
+
+  let result: T | undefined;
+  let error: unknown;
+  await context.run(ctx, async () => {
     try {
-      step();
-    } catch (step: any) {
-      const stepState: StepState = {
-        runId: crypto.randomUUID(),
-        stepId: step.id(),
-        result: null,
-        error: null,
-        attempt: 0,
-      };
-
-      await step.run(storage, stepState, AbortSignal.timeout(1000));
-
-      return stepState;
+      result = await body();
+    } catch (e) {
+      error = e;
     }
+  });
 
-    throw new Error("Unreachable");
-  }
+  return { ctx, result, error, storage };
+}
 
+describe("step", () => {
   test("regular step", async () => {
-    const storage = new InMemoryAdapter();
-
     const fn = vi.fn(() => Promise.resolve("foo"));
     const sut = step<void, string>(fn);
 
-    const stepState = await runStep(sut, storage);
+    const { ctx, result, storage } = await withContext(() => sut());
 
-    expect(stepState.result).toBe("foo");
-    expect(await storage.getSteps(stepState.runId)).toEqual(
-      new Map([[stepState.stepId, stepState]]),
+    expect(result).toBe("foo");
+    const [stepState] = ctx.stepState.values();
+    expect(stepState?.result).toBe("foo");
+    expect(await storage.getSteps(ctx.runId)).toEqual(
+      new Map([[stepState!.stepId, stepState]]),
     );
   });
 
   test("resolve on first retry", async () => {
-    const fn = vi.fn(() => Promise.resolve("foo"));
-    fn.mockThrowOnce(new Error("NEIN"));
+    let calls = 0;
+    const fn = vi.fn(() => {
+      calls++;
+      if (calls === 1) return Promise.reject(new Error("NEIN"));
+      return Promise.resolve("foo");
+    });
+    const sut = step<void, string>({ baseTimeout: 1 }, fn);
 
-    const sut = step<void, string>(fn);
+    const { ctx, result } = await withContext(() => sut());
 
-    const stepState = await runStep(sut);
-
-    expect(stepState.result).toBe("foo");
-    expect(stepState.attempt).toBe(2);
+    expect(result).toBe("foo");
+    const [stepState] = ctx.stepState.values();
+    expect(stepState?.attempt).toBe(2);
   });
 
   test("fails after n retries", async () => {
-    const storage = new InMemoryAdapter();
     const fn = vi.fn(() => Promise.reject("NEIN"));
     const sut = step<void, string>({ baseTimeout: 1 }, fn);
 
-    const runId = crypto.randomUUID();
-    let stepId = "";
+    const { error, ctx, storage } = await withContext(() => sut());
 
-    try {
-      sut();
-    } catch (s: any) {
-      stepId = s.id();
-      const stepState: StepState = { runId, stepId, result: null, error: null, attempt: 0 };
-      await expect(() =>
-        s.run(storage, stepState, AbortSignal.timeout(1000)),
-      ).rejects.toThrow("NEIN");
-    }
-
-    const steps = await storage.getSteps(runId);
+    expect(String(error)).toContain("NEIN");
+    const steps = await storage.getSteps(ctx.runId);
     const [savedStep] = steps.values();
-
-    expect(savedStep.error).toBe("NEIN");
+    expect(savedStep?.error).toBe("NEIN");
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
   test("fails immediately on fatal error", async () => {
-    const storage = new InMemoryAdapter();
     const fn = vi.fn(() => Promise.reject(new FatalError("NEIN")));
     const sut = step<void, string>({ baseTimeout: 1 }, fn);
 
-    const runId = crypto.randomUUID();
+    const { error, ctx, storage } = await withContext(() => sut());
 
-    try {
-      sut();
-    } catch (s: any) {
-      const stepState: StepState = { runId, stepId: s.id(), result: null, error: null, attempt: 0 };
-      await expect(() =>
-        s.run(storage, stepState, AbortSignal.timeout(1000)),
-      ).rejects.toThrow("NEIN");
-    }
-
-    const steps = await storage.getSteps(runId);
+    expect(error).toBeInstanceOf(FatalError);
+    expect((error as Error).message).toBe("NEIN");
+    const steps = await storage.getSteps(ctx.runId);
     const [savedStep] = steps.values();
-
-    expect(savedStep.error).toBe("FatalError: NEIN");
+    expect(savedStep?.error).toBe("FatalError: NEIN");
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
   test("throws original error on fatal error", async () => {
-    const storage = new InMemoryAdapter();
     const fn = vi.fn(() =>
       Promise.reject(FatalError.from(new TypeError("NEIN"))),
     );
     const sut = step<void, string>({ baseTimeout: 1 }, fn);
 
-    const runId = crypto.randomUUID();
+    const { error, ctx, storage } = await withContext(() => sut());
 
-    try {
-      sut();
-    } catch (s: any) {
-      const stepState: StepState = { runId, stepId: s.id(), result: null, error: null, attempt: 0 };
-      await expect(() =>
-        s.run(storage, stepState, AbortSignal.timeout(1000)),
-      ).rejects.toThrow(TypeError);
-    }
-
-    const steps = await storage.getSteps(runId);
+    expect(error).toBeInstanceOf(TypeError);
+    const steps = await storage.getSteps(ctx.runId);
     const [savedStep] = steps.values();
+    expect(savedStep?.error).toBe("TypeError: NEIN");
+  });
 
-    expect(savedStep.error).toBe("TypeError: NEIN");
+  test("step() outside of a workflow throws", async () => {
+    const sut = step<void, string>(() => Promise.resolve("foo"));
+    await expect(() => sut()).rejects.toThrow(/inside a workflow/);
+  });
+
+  test("cached successful result is returned without re-running", async () => {
+    const fn = vi.fn(() => Promise.resolve("foo"));
+    const sut = step<void, string>(fn);
+
+    const ctx: RunContext = {
+      runId: crypto.randomUUID(),
+      storage: new InMemoryAdapter(),
+      abortSignal: AbortSignal.timeout(5000),
+      stepState: new Map(),
+      callIndex: 0,
+    };
+
+    await context.run(ctx, async () => {
+      await sut();
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    ctx.callIndex = 0;
+    let cached: string | undefined;
+    await context.run(ctx, async () => {
+      cached = await sut();
+    });
+    expect(cached).toBe("foo");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("cached error is re-thrown on replay without re-running", async () => {
+    const fn = vi.fn(() => Promise.reject(new Error("NEIN")));
+    const sut = step<void, string>({ baseTimeout: 1 }, fn);
+
+    const ctx: RunContext = {
+      runId: crypto.randomUUID(),
+      storage: new InMemoryAdapter(),
+      abortSignal: AbortSignal.timeout(5000),
+      stepState: new Map(),
+      callIndex: 0,
+    };
+
+    let firstError: unknown;
+    await context.run(ctx, async () => {
+      try {
+        await sut();
+      } catch (e) {
+        firstError = e;
+      }
+    });
+    expect((firstError as Error).message).toBe("NEIN");
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    ctx.callIndex = 0;
+    let replayError: unknown;
+    await context.run(ctx, async () => {
+      try {
+        await sut();
+      } catch (e) {
+        replayError = e;
+      }
+    });
+    expect((replayError as Error).message).toBe("Error: NEIN");
+    expect(fn).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/1-workflow/src/step.ts
+++ b/packages/1-workflow/src/step.ts
@@ -28,6 +28,7 @@ async function runWithRetries<I, O>(
   storage: Adapter,
   abortSignal: AbortSignal,
 ): Promise<O> {
+  let lastError: unknown;
   while (state.attempt < attempts) {
     state.attempt++;
     if (abortSignal.aborted) {
@@ -47,19 +48,19 @@ async function runWithRetries<I, O>(
         await storage.putStep(state);
         throw cause;
       }
+      lastError = error;
       state.error = String(error);
       await storage.putStep(state);
-      if (state.attempt === attempts) {
-        throw error;
-      }
     }
+
+    if (state.attempt >= attempts) break;
 
     const delay = baseTimeout * 2 ** (state.attempt - 1);
     await storage.lease(state.runId, delay);
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
 
-  throw new Error("Step retry budget exhausted");
+  throw lastError;
 }
 
 export function step<I, O>(

--- a/packages/1-workflow/src/step.ts
+++ b/packages/1-workflow/src/step.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
-import { context } from "./context.js";
 import type { Adapter, StepState } from "./adapter.js";
+import { context } from "./context.js";
 import { FatalError } from "./fatal-error.js";
 
 interface StepConfig {
@@ -8,92 +8,108 @@ interface StepConfig {
   baseTimeout?: number;
 }
 
-export class Step<I = unknown> {
-  private attempts: number;
-  private baseTimeout: number;
+type StepImpl<I, O> = (input: I) => Promise<O>;
+type StepRunner<I, O> = (input: I) => Promise<O>;
 
-  constructor(
-    private fn: (input: I) => Promise<unknown>,
-    private input: I,
-    { attempts = 3, baseTimeout = 250 }: StepConfig,
-  ) {
-    this.attempts = attempts;
-    this.baseTimeout = baseTimeout;
-  }
-
-  async run(storage: Adapter, state: StepState, abortSignal: AbortSignal) {
-    while (state.attempt < this.attempts) {
-      state.attempt++;
-      if (abortSignal.aborted) {
-        throw new Error(abortSignal.reason);
-      }
-
-      try {
-        state.result = await this.fn(this.input);
-        state.error = null;
-        return;
-      } catch (error) {
-        if (error instanceof FatalError) {
-          state.error = String(error.cause ?? error);
-          throw error.cause ?? error;
-        }
-        state.error = String(error);
-        if (state.attempt === this.attempts) {
-          throw error;
-        }
-      } finally {
-        await storage.putStep(state);
-      }
-
-      const delay = this.baseTimeout * 2 ** (state.attempt - 1);
-
-      await storage.lease(state.runId, delay);
-
-      await new Promise((resolve) =>
-        setTimeout(resolve, this.baseTimeout * 2 ** (state.attempt - 1)),
-      );
-    }
-  }
-
-  id() {
-    const hash = crypto.createHash("md5");
-
-    if (this.fn.name) hash.update(this.fn.name);
-    if (this.fn.toString()) hash.update(this.fn.toString());
-    if (this.input) hash.update(JSON.stringify(this.input));
-
-    return hash.digest("hex");
-  }
-
-  [Symbol.toPrimitive]() {
-    return `[Step id=${this.id()} if you are seeing this you are probably catching an error in a workflow and need to call rethrowSuspense before your own error handling]`;
-  }
+function hashStep(fn: (...args: any[]) => unknown, input: unknown): string {
+  const hash = crypto.createHash("md5");
+  if (fn.name) hash.update(fn.name);
+  if (fn.toString()) hash.update(fn.toString());
+  if (input !== undefined) hash.update(JSON.stringify(input));
+  return hash.digest("hex");
 }
 
-type StepImpl<I, O> = (input: I) => Promise<O>
+async function runWithRetries<I, O>(
+  fn: StepImpl<I, O>,
+  input: I,
+  attempts: number,
+  baseTimeout: number,
+  state: StepState,
+  storage: Adapter,
+  abortSignal: AbortSignal,
+): Promise<O> {
+  while (state.attempt < attempts) {
+    state.attempt++;
+    if (abortSignal.aborted) {
+      throw new Error(abortSignal.reason);
+    }
 
-type RunStep<I, O> = (input: I) => O
+    try {
+      const result = await fn(input);
+      state.result = result;
+      state.error = null;
+      await storage.putStep(state);
+      return result;
+    } catch (error) {
+      if (error instanceof FatalError) {
+        const cause = error.cause ?? error;
+        state.error = String(cause);
+        await storage.putStep(state);
+        throw cause;
+      }
+      state.error = String(error);
+      await storage.putStep(state);
+      if (state.attempt === attempts) {
+        throw error;
+      }
+    }
+
+    const delay = baseTimeout * 2 ** (state.attempt - 1);
+    await storage.lease(state.runId, delay);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
+  throw new Error("Step retry budget exhausted");
+}
 
 export function step<I, O>(
   config: StepConfig,
   run: StepImpl<I, O>,
-): RunStep<I, O>;
-export function step<I, O>(run: StepImpl<I, O>): RunStep<I, O>;
+): StepRunner<I, O>;
+export function step<I, O>(run: StepImpl<I, O>): StepRunner<I, O>;
 export function step<I, O>(
   arg0: StepConfig | StepImpl<I, O>,
   arg1?: StepImpl<I, O>,
-) {
+): StepRunner<I, O> {
   const config = typeof arg0 === "function" ? {} : arg0;
-  const run = typeof arg0 === "function" ? arg0 : arg1!;
-  return (input: I) => {
-    const step = new Step(run, input, config);
-    const state = context.stepState.get(step.id());
-    if (state?.errorObject) {
-      throw state.errorObject;
+  const fn = typeof arg0 === "function" ? arg0 : arg1!;
+  const attempts = config.attempts ?? 3;
+  const baseTimeout = config.baseTimeout ?? 250;
+
+  return async (input: I): Promise<O> => {
+    const ctx = context.getStore();
+    if (!ctx) {
+      throw new Error("step() must be called from inside a workflow");
     }
-    if (state && !state.error) {
-      return state.result as O;
+
+    const callIndex = ctx.callIndex++;
+    const stepId = `${hashStep(fn, input)}:${callIndex}`;
+
+    const cached = ctx.stepState.get(stepId);
+    if (cached) {
+      if (cached.error !== null) {
+        throw new Error(cached.error);
+      }
+      return cached.result as O;
     }
-    throw step;
+
+    const state: StepState = {
+      runId: ctx.runId,
+      stepId,
+      result: null,
+      error: null,
+      attempt: 0,
+    };
+    ctx.stepState.set(stepId, state);
+
+    return await runWithRetries(
+      fn,
+      input,
+      attempts,
+      baseTimeout,
+      state,
+      ctx.storage,
+      ctx.abortSignal,
+    );
   };
 }

--- a/packages/1-workflow/src/workflow.ts
+++ b/packages/1-workflow/src/workflow.ts
@@ -1,45 +1,22 @@
-import type { Adapter, StepState, WorkflowState } from "./adapter.js";
-import { context } from "./context.js";
-import { Step } from "./step.js";
+import type { Adapter, WorkflowState } from "./adapter.js";
+import { context, type RunContext } from "./context.js";
 
-export function workflow<I = void>(gen: (input: I) => void) {
+export function workflow<I = void>(gen: (input: I) => Promise<void>) {
   return new Workflow(gen);
 }
 
 export class Workflow<I> {
-  constructor(private gen: (input: I) => void) {}
+  constructor(private gen: (input: I) => Promise<void>) {}
 
   async run(storage: Adapter, state: WorkflowState, abortSignal: AbortSignal) {
     const steps = await storage.getSteps(state.runId);
-
-    while (true) {
-      if (abortSignal.aborted) {
-        throw new Error(abortSignal.reason);
-      }
-      try {
-        context.stepState = steps;
-        this.gen(state.input as I);
-        return;
-      } catch (v) {
-        if (v instanceof Step) {
-          const stepState: StepState & { errorObject?: unknown } = {
-            runId: state.runId,
-            stepId: v.id(),
-            result: null,
-            error: null,
-            attempt: 0,
-          };
-          steps.set(v.id(), stepState);
-          try {
-            await v.run(storage, stepState, abortSignal);
-          } catch (e) {
-            stepState.errorObject = e;
-          }
-          continue;
-        }
-
-        throw v;
-      }
-    }
+    const ctx: RunContext = {
+      runId: state.runId,
+      storage,
+      abortSignal,
+      stepState: steps,
+      callIndex: 0,
+    };
+    await context.run(ctx, () => this.gen(state.input as I));
   }
 }


### PR DESCRIPTION
Closes #326.

## Summary

Workflows are now async functions, and `step()` returns a `Promise`. The engine binds a per-run [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) context around the workflow function, so steps look up their cached state through normal `await`s instead of the synchronous throw-then-replay sentinel.

```ts
// Before
workflow((userId: string) => {
  const user = fetchUser(userId);
  sendEmail(user.email);
})

// After
workflow(async (userId: string) => {
  const user = await fetchUser(userId);
  await sendEmail(user.email);
})
```

## What changed

- **`step()` returns `Promise<O>`.** No more synchronous `throw` of a `Step` instance.
- **`workflow(gen)`** requires `gen: (input) => Promise<void>`.
- **`rethrowSuspense` is removed.** With real async errors, plain `try/catch` around an `await step(...)` works as you'd expect.
- **Parallel steps work**: `await Promise.all([stepA(input), stepB(input)])`.
- **Step IDs** now include a per-run invocation counter (`md5(fn + input):callIndex`) so the same step can be called multiple times — in a loop or in parallel — without colliding.
- `context` is now an `AsyncLocalStorage<RunContext>` instead of a module-level mutable singleton.
- **Behavior change worth knowing**: on worker restart, a step with a persisted error now throws deterministically on replay instead of being re-executed. The retry budget was already exhausted in the previous run.

## Files

- `src/context.ts` — switched to `AsyncLocalStorage<RunContext>` carrying runId, storage, abort signal, step-state map, and a `callIndex` counter.
- `src/step.ts` — `step()` becomes an async function that reads the ALS context, derives a deterministic ID, and either returns the cached result, re-throws the cached error, or runs the underlying function with retries/backoff/persistence.
- `src/workflow.ts` — `Workflow.run` builds the run context and calls the workflow's async function inside `context.run(...)`. No more while-loop replay.
- `src/rethrow-suspense.ts` — deleted.
- `src/index.ts` — drop `rethrowSuspense` export.
- Tests in `src/{engine,step}.test.ts` and all adapter tests ported to the async shape; added new tests for parallel steps, multi-invocation determinism, cached-result reuse, and cached-error replay.
- `README.md` — rewrite the "How it works" section and the quick-start.
- Changeset: minor bump.

## Test plan

- [x] `pnpm test --run` in `packages/1-workflow` — 22 tests pass (engine, step, sqlite, drizzle-better-sqlite, postgres).
- [x] `pnpm build` clean.
- [x] `pnpm lint` clean (25 warnings, all pre-existing; baseline was 27).
- [x] `rg rethrowSuspense` across repo — no remaining references.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Ebq4UnNqZMdDCqdYUBWqj)_