### PR TITLE
feat(vite-plugin-tapi): production server serves client build with SPA fallback

### DIFF
--- a/.changeset/vite-plugin-tapi-serve-static.md
+++ b/.changeset/vite-plugin-tapi-serve-static.md
@@ -1,0 +1,24 @@
+---
+"@farbenmeer/vite-plugin-tapi": minor
+---
+
+vite-plugin-tapi: the production server now serves the client build with SPA fallback
+
+The bundled `dist/server.js` previously handled only the API and returned `404`
+for every other path, so serving the frontend in production meant either
+`vite preview` (a dev server that rejects unknown `Host` headers via
+`preview.allowedHosts` — breaking behind preview proxies) or `srvx -s client`
+(whose static handler has no history fallback, so refreshing a client route
+404s).
+
+`dist/server.js` is now a complete single-host server: API routes under
+`basePath`, static files from the sibling `./client`, and an `index.html` SPA
+fallback for unmatched `GET`/`HEAD` navigations. Deployment is just
+`srvx serve --entry dist/server.js` — no `-s` flag, no separate static host,
+and client-side routes survive deep-links and reloads.
+
+A new `static` option controls this: `true` (default) serves static + SPA
+fallback; `false` keeps the old API-only bundle (for a dedicated static host /
+CDN or a runtime without filesystem access); `{ fallback: false }` serves
+static files without the SPA fallback; `{ fallback: "404.html" }` uses a custom
+fallback file.

--- a/packages/3-vite-plugin-tapi/README.md
+++ b/packages/3-vite-plugin-tapi/README.md
@@ -50,6 +50,7 @@ and the API on a single port.
 | `basePath` | `string` | `"/api"` | Prefix for API routes. Use `""` to mount at the root. |
 | `port` | `number` | — | Default port for Vite's dev/preview server. Falls back to the `PORT` env var. |
 | `external` | `(string \| RegExp)[]` | `[]` | Packages to keep external in the server bundle. By default everything is bundled. |
+| `static` | `boolean \| { fallback?: boolean \| string }` | `true` | Whether the production server (`dist/server.js`) serves the client build + SPA fallback. `false` keeps it API-only (dedicated static host / CDN). See [Deployment](#deployment). |
 
 ## Environment variables
 
@@ -71,7 +72,7 @@ This covers server-side libraries that read `process.env.X` directly
 (BetterAuth, DB clients, OAuth secrets). Vite's `import.meta.env` injection
 still applies to client code.
 
-### Production (`srvx dist/server/server.js`)
+### Production (`srvx serve --entry dist/server.js`)
 
 The built server does **not** load `.env` files. In production, env vars come
 from the runtime — Docker, systemd, or your PaaS. 
@@ -172,30 +173,35 @@ Notes:
 
 ## Deployment
 
-The server bundle is a fetch-handler module. Serve it in production with the
-[srvx](https://srvx.h3.dev) CLI:
+The server bundle is a fetch-handler module. By default it is a complete
+single-host server: it serves the API under `basePath`, the static client from
+the sibling `dist/client/`, and falls back to `index.html` for unmatched
+navigations so history-routed SPAs survive deep-links and reloads. Serve it in
+production with the [srvx](https://srvx.h3.dev) CLI:
 
 ```bash
-srvx --prod dist/server.js
+srvx serve --entry dist/server.js
 ```
 
-`srvx` picks up `PORT`, `HOST`, and other settings from environment variables.
+No `-s` flag and no separate static host are needed — the bundle serves its own
+client. `srvx` picks up `PORT`, `HOST`, and other settings from environment
+variables.
 
-### Static assets
+> Static serving uses `node:fs`, so it requires a Node/Bun/Deno runtime with
+> filesystem access.
 
-Static frontend assets in `dist/client/` should ideally be served by a
-dedicated static host — nginx, Caddy, or an S3-compatible bucket fronted by a
-CDN. Dedicated static hosts give you better caching, compression, HTTP/2,
-and offload the load from your Node.js server.
+### Serving static assets elsewhere
 
-If you don't want a separate static host, srvx can serve them too with the
-`-s` flag:
+To put the static frontend on a dedicated static host instead — nginx, Caddy,
+or an S3-compatible bucket fronted by a CDN, for better caching, compression,
+and HTTP/2 — set `static: false` so `dist/server.js` stays API-only and deploy
+`dist/client/` separately:
 
-```bash
-srvx --prod -s client dist/server.js
+```ts
+tapi({ static: false });
 ```
 
-The path passed to `-s` is resolved **relative to the directory containing
-the entry file** (`dist/`), so `client` points at `dist/client/`.
-API routes are matched first; static files fall through when no API route
-handles the request.
+The `static` option also accepts `{ fallback: false }` (serve static files but
+`404` instead of the SPA fallback, for multi-page apps) and
+`{ fallback: "404.html" }` (use a custom fallback file, resolved relative to
+`dist/client/`).

--- a/packages/3-vite-plugin-tapi/src/index.ts
+++ b/packages/3-vite-plugin-tapi/src/index.ts
@@ -26,11 +26,140 @@ export interface TapiPluginOptions {
    * Default: `[]` — everything is bundled.
    */
   external?: (string | RegExp)[];
+  /**
+   * How the production server (`dist/server.js`) serves the client build.
+   *
+   * By default the bundled server serves the static client
+   * (`<outDir>/client`, a sibling of `server.js`) and, for navigations that
+   * match no file, falls back to `index.html` so history-routed SPAs survive
+   * deep-links and reloads. This makes `srvx serve --entry dist/server.js` a
+   * complete single-host deployment — no `-s` flag, no separate static host.
+   *
+   * Static serving uses `node:fs`, so it requires a Node/Bun/Deno runtime
+   * with filesystem access (the documented `srvx` deployment).
+   *
+   * - `true` (default): serve static files + SPA fallback to `index.html`.
+   * - `false`: API only — the client is served by a dedicated static host /
+   *   CDN, or a runtime without filesystem access (Workers).
+   * - `{ fallback: false }`: serve static files but `404` instead of the SPA
+   *   fallback (multi-page apps without client-side routing).
+   * - `{ fallback: "404.html" }`: serve that file (relative to the client
+   *   dir) for unmatched navigations instead of `index.html`.
+   *
+   * Default: `true`.
+   */
+  static?: boolean | { fallback?: boolean | string };
+}
+
+/**
+ * Generate the source of the bundled production server (`dist/server.js`).
+ *
+ * `serveClient: false` reproduces the historical API-only handler. Otherwise
+ * the handler composes three layers, in order:
+ *   1. API routes under `basePath` (handled by `createRequestHandler`),
+ *   2. static files from `./client` (the sibling client build), and
+ *   3. an `index.html` SPA fallback for unmatched GET/HEAD navigations.
+ *
+ * With an empty `basePath` the API is root-mounted, so static files are tried
+ * first and the API gets a chance before the SPA fallback.
+ */
+function buildServerModule(opts: {
+  resolvedEntry: string;
+  basePath: string;
+  serveClient: boolean;
+  spaFallback: string | null;
+}): string {
+  const { resolvedEntry, basePath, serveClient, spaFallback } = opts;
+
+  if (!serveClient) {
+    return [
+      `import { createRequestHandler } from "@farbenmeer/tapi/server";`,
+      `import { api } from ${JSON.stringify(resolvedEntry)};`,
+      ``,
+      `export const fetch = createRequestHandler(api, { basePath: ${JSON.stringify(basePath)} });`,
+      `export default { fetch };`,
+    ].join("\n");
+  }
+
+  return [
+    `import { createRequestHandler } from "@farbenmeer/tapi/server";`,
+    `import { serveStatic } from "srvx/static";`,
+    `import { readFileSync } from "node:fs";`,
+    `import { fileURLToPath } from "node:url";`,
+    `import { api } from ${JSON.stringify(resolvedEntry)};`,
+    ``,
+    `const basePath = ${JSON.stringify(basePath)};`,
+    `const apiFetch = createRequestHandler(api, { basePath });`,
+    ``,
+    // The client build is emitted next to this module as ./client.
+    `const clientDir = fileURLToPath(new URL("./client", import.meta.url));`,
+    `const serveAsset = serveStatic({ dir: clientDir });`,
+    ``,
+    `const fallbackFile = ${JSON.stringify(spaFallback)};`,
+    `let fallbackHtml;`,
+    `if (fallbackFile) {`,
+    `  try {`,
+    `    fallbackHtml = readFileSync(new URL("./client/" + fallbackFile, import.meta.url));`,
+    `  } catch {`,
+    // No index.html shipped (e.g. API-only client dir) — skip the fallback.
+    `    fallbackHtml = undefined;`,
+    `  }`,
+    `}`,
+    ``,
+    // Sentinel so a static miss is distinguishable from a real Response.
+    `const MISS = Symbol("tapi:static-miss");`,
+    ``,
+    `export const fetch = async (request) => {`,
+    `  const { pathname } = new URL(request.url);`,
+    ``,
+    // A non-empty basePath cleanly separates API routes from static assets.
+    `  if (basePath && (pathname === basePath || pathname.startsWith(basePath + "/"))) {`,
+    `    return apiFetch(request);`,
+    `  }`,
+    ``,
+    `  const asset = await serveAsset(request, () => MISS);`,
+    `  if (asset !== MISS) return asset;`,
+    ``,
+    // Root-mounted API: let it answer before we reach for the SPA fallback.
+    `  if (!basePath) {`,
+    `    const apiResponse = await apiFetch(request);`,
+    `    if (apiResponse.status !== 404) return apiResponse;`,
+    `  }`,
+    ``,
+    `  if (fallbackHtml && (request.method === "GET" || request.method === "HEAD")) {`,
+    `    return new Response(fallbackHtml, {`,
+    `      headers: {`,
+    `        "content-type": "text/html; charset=utf-8",`,
+    // The shell references hashed assets; never cache the shell itself.
+    `        "cache-control": "no-cache",`,
+    `      },`,
+    `    });`,
+    `  }`,
+    ``,
+    `  return new Response("Not Found", { status: 404 });`,
+    `};`,
+    `export default { fetch };`,
+  ].join("\n");
 }
 
 export default function tapi(options: TapiPluginOptions = {}): Plugin {
   const entryOption = options.entry ?? "src/api.ts";
   const basePath = options.basePath ?? "/api";
+
+  // Resolve the `static` option into the production server's behavior:
+  // `serveClient` toggles static file serving, `spaFallback` is the file
+  // served for unmatched navigations (or `null` to 404 instead).
+  const staticOption = options.static ?? true;
+  const serveClient = staticOption !== false;
+  const spaFallback: string | null = !serveClient
+    ? null
+    : staticOption === true || staticOption.fallback === undefined
+      ? "index.html"
+      : staticOption.fallback === true
+        ? "index.html"
+        : staticOption.fallback === false
+          ? null
+          : staticOption.fallback;
 
   let userOutDirBase = "dist";
   let resolvedEntry = "";
@@ -151,12 +280,12 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
         fetchHandler = mod.default?.fetch ?? mod.fetch;
         if (!fetchHandler) {
           console.warn(
-            "[vite-plugin-tapi] dist/server/server.js has no fetch export — run `vite build` first.",
+            "[vite-plugin-tapi] dist/server.js has no fetch export — run `vite build` first.",
           );
         }
       } catch (err) {
         console.error(
-          "[vite-plugin-tapi] failed to import dist/server/server.js for preview:",
+          "[vite-plugin-tapi] failed to import dist/server.js for preview:",
           err,
         );
       }
@@ -180,13 +309,12 @@ export default function tapi(options: TapiPluginOptions = {}): Plugin {
         },
         load(id) {
           if (id !== RESOLVED_VIRTUAL_SERVER_ID) return null;
-          return [
-            `import { createRequestHandler } from "@farbenmeer/tapi/server";`,
-            `import { api } from ${JSON.stringify(resolvedEntry)};`,
-            ``,
-            `export const fetch = createRequestHandler(api, { basePath: ${JSON.stringify(basePath)} });`,
-            `export default { fetch };`,
-          ].join("\n");
+          return buildServerModule({
+            resolvedEntry,
+            basePath,
+            serveClient,
+            spaFallback,
+          });
         },
       });
 

--- a/website/src/content/docs/vite-plugin-tapi/guides/deployment.md
+++ b/website/src/content/docs/vite-plugin-tapi/guides/deployment.md
@@ -18,25 +18,25 @@ Server-only code (database credentials, API keys, server-side libraries) lives i
 
 ## Running the Server
 
-The server bundle is a fetch-handler module. Serve it with the [srvx](https://srvx.h3.dev) CLI:
+The server bundle is a fetch-handler module. By default it is a complete single-host server: it serves the API under `basePath`, the static client from the sibling `dist/client/`, and falls back to `index.html` for unmatched navigations so history-routed SPAs survive deep-links and reloads. Serve it with the [srvx](https://srvx.h3.dev) CLI:
 
 ```bash
-srvx --prod dist/server.js
+srvx serve --entry dist/server.js
 ```
 
-`srvx` picks up `PORT`, `HOST`, and other settings from environment variables.
+No `-s` flag and no separate static host are needed — the bundle serves its own client. `srvx` picks up `PORT`, `HOST`, and other settings from environment variables.
 
-## Serving Static Assets
+Static serving uses `node:fs`, so it requires a Node/Bun/Deno runtime with filesystem access.
 
-Static assets in `dist/client/` should ideally be served by a dedicated static host — nginx, Caddy, or an S3-compatible bucket fronted by a CDN — for better caching, compression, and HTTP/2.
+## Serving Static Assets Elsewhere
 
-If you don't need a separate static host, srvx can serve them too with the `-s` flag:
+To put the static frontend on a dedicated static host instead — nginx, Caddy, or an S3-compatible bucket fronted by a CDN, for better caching, compression, and HTTP/2 — set `static: false` so `dist/server.js` stays API-only, and deploy `dist/client/` separately:
 
-```bash
-srvx --prod -s client dist/server.js
+```ts
+tapi({ static: false });
 ```
 
-The path passed to `-s` is resolved relative to the directory containing the entry file (`dist/`), so `client` points at `dist/client/`. API routes are matched first; static files fall through when no API route handles the request.
+The `static` option also accepts `{ fallback: false }` (serve static files but `404` instead of the SPA fallback, for multi-page apps) and `{ fallback: "404.html" }` (use a custom fallback file, resolved relative to `dist/client/`).
 
 ## Environment Variables
 

--- a/website/src/content/docs/vite-plugin-tapi/guides/getting-started.md
+++ b/website/src/content/docs/vite-plugin-tapi/guides/getting-started.md
@@ -49,6 +49,7 @@ In dev (`vite`) and preview (`vite preview`) the API is mounted as middleware at
 | `basePath` | `string` | `"/api"` | Prefix for API routes. Use `""` to mount at the root. |
 | `port` | `number` | — | Default port for Vite's dev/preview server. Falls back to the `PORT` env var. |
 | `external` | `(string \| RegExp)[]` | `[]` | Packages to keep external in the server bundle. |
+| `static` | `boolean \| { fallback?: boolean \| string }` | `true` | Whether `dist/server.js` serves the client build + SPA fallback. `false` keeps it API-only (dedicated static host / CDN). See [Deployment](./deployment). |
 
 ## Environment Variables
 


### PR DESCRIPTION
## Problem

The bundled production server `dist/server.js` handles **only the API** — `createRequestHandler` returns a plain `404 Not Found` for every non-API path ([`create-request-handler.js`](https://github.com/farbenmeer/tapi/blob/main/packages/1-tapi/src/server/create-request-handler.ts)). So there's currently no clean way to serve a history-routed tapi SPA in production:

- **`vite preview`** is a dev server and rejects unknown `Host` headers via `preview.allowedHosts`. Behind a preview proxy (e.g. Scaleway/mini-paas) you get:
  > `Blocked request. This host ("…functions.fnc.fr-par.scw.cloud") is not allowed.`
- **`srvx -s client dist/server.js`** (per the current docs) works for assets, but srvx's `serveStatic` has **no SPA/history fallback** — it only tries `path`, `path.html`, `path/index.html`. Refreshing or deep-linking any client route (e.g. `/:engagement/roadmap/:period`) 404s.

## Fix

Make `dist/server.js` a **complete single-host server**. The generated bundle now composes three layers:

1. API routes under `basePath` (`createRequestHandler`),
2. static files from the sibling `./client` (via `srvx/static`),
3. an `index.html` SPA fallback for unmatched `GET`/`HEAD` navigations.

Deployment becomes just:

```bash
srvx serve --entry dist/server.js
```

No `-s` flag, no separate static host, and client routes survive deep-links/reloads. The client/server output split is preserved (server.js serving `./client` is additive — it's a server, not a public static host).

### New `static` option

```ts
tapi({ static: true })                       // default: static + SPA fallback
tapi({ static: false })                      // API-only (dedicated static host / CDN / Workers)
tapi({ static: { fallback: false } })        // static files, but 404 instead of SPA fallback (MPA)
tapi({ static: { fallback: "404.html" } })   // custom fallback file
```

With an empty `basePath` (root-mounted API) the handler tries static first, then lets the API answer before falling back.

### Also

- Fixes stale `dist/server/server.js` strings in the preview warnings (the code resolves `dist/server.js`).
- Corrects `srvx --prod dist/server.js` → `srvx serve --entry dist/server.js` in README + website docs, documents the new default and `static` option.

## Notes / review

- Static serving uses `node:fs`, so it requires a Node/Bun/Deno runtime with filesystem access (the documented `srvx` deployment). Workers users set `static: false`.
- `srvx` is already a direct dependency of the plugin; `srvx/static` is bundled into `server.js` by the existing `ssr.noExternal: true` build.
- **`vite preview` is unaffected:** with a non-empty `basePath`, `createApiMiddleware` only forwards `/api/*` to the bundled handler and calls `next()` otherwise, so vite keeps serving static + its own SPA fallback in preview.

## Testing

Verified end-to-end against a real consumer app (history-routed, `@farbenmeer/router`) built with the patched plugin and served via `srvx serve --entry dist/server.js` (no `-s`):

| Request | Result |
|---|---|
| `GET /` | `200 text/html` (shell) |
| `GET /api/health` | `200` `{"status":"ok"}` |
| `GET /assets/index-*.js` | `200 text/javascript` |
| `GET /engagements` (deep route) | `200 text/html` — serves the app shell |
| `GET /:engagement/roadmap/2026-Q2` (nested) | `200 text/html` |
| `GET /api/nope` (unknown API) | `404` (tapi's own 404) |
| `POST /engagements` (non-GET nav) | `404` (no HTML) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)