### PR TITLE
fix: ensure lists update when a mutation (archive/delete) triggers cache revalidation

### DIFF
--- a/packages/1-tapi/src/server/t-response.ts
+++ b/packages/1-tapi/src/server/t-response.ts
@@ -29,11 +29,13 @@ export class TResponse<T = unknown> extends Response {
       );
     }
     if (cookies) {
-      init.headers =
-        init.headers instanceof Headers
-          ? init.headers
-          : new Headers(init.headers);
-      cookies.write(init.headers);
+      // Write cookies to the same headers object used for the response body,
+      // so they are included alongside any cache headers set above.
+      cookies.write(
+        rawInit.headers instanceof Headers
+          ? rawInit.headers
+          : (rawInit.headers = new Headers(rawInit.headers)),
+      );
     }
     super(body, rawInit);
     this.cache = cache;

--- a/packages/2-react-tapi/src/use-query.ts
+++ b/packages/2-react-tapi/src/use-query.ts
@@ -21,9 +21,16 @@ export function useQuery<T>(
 
   React.useEffect(() => {
     const unsubscribe = observable.subscribe((next) => {
-      startTransition(async () => {
-        setData(await next);
-      });
+      void next.then(
+        (value) => {
+          startTransition(() => {
+            setData(value);
+          });
+        },
+        // Revalidation failed — keep showing the current (stale) data.
+        // The error is already logged by the cache layer.
+        () => {},
+      );
     });
     return unsubscribe;
   }, [observable]);


### PR DESCRIPTION
## Problem

The session/thread list does not update when a thread is archived (or any item is deleted/mutated). The list shows stale data even though the mutation response includes the correct cache tags for revalidation.

## Root Causes

### 1. `useQuery` transition wrapping (primary fix)

The subscription callback in `useQuery` wrapped the entire async resolution inside `startTransition`:

```ts
startTransition(async () => {
  setData(await next);
});
```

This kept React's transition pending while awaiting the revalidation promise. If React interrupted the transition (e.g., due to a concurrent navigation) or if the transition took too long, the `setData` call could be dropped — leaving the list permanently showing stale data.

**Fix**: Resolve the promise outside the transition and only wrap the synchronous `setData`:

```ts
void next.then(
  (value) => startTransition(() => setData(value)),
  () => {}  // silently catch revalidation errors (already logged by cache)
);
```

### 2. `TResponse` cookie/cache header conflict

When both `cache` tags and `cookies` were set on a `TResponse`, the cookies were written to `init.headers` while cache headers were written to `rawInit.headers` (the object passed to the `Response` constructor). Since `rawInit` is a shallow spread of `init`, the two headers objects could diverge after `setHeader()` created a new `Headers` instance — causing cookies to be silently dropped from the response.

**Fix**: Write cookies to `rawInit.headers` instead of `init.headers`, ensuring they coexist with cache-tag headers on the actual response.

## Changes

- `packages/1-tapi/src/server/t-response.ts` — Write cookies to `rawInit.headers`
- `packages/2-react-tapi/src/use-query.ts` — Resolve promise outside transition + error handling