### PR TITLE
fix(vite-plugin-tapi-demo): cache headers on the reference Caddyfile

### DIFF
--- a/.changeset/prod-serving-static-caching.md
+++ b/.changeset/prod-serving-static-caching.md
@@ -1,0 +1,17 @@
+---
+"@farbenmeer/vite-plugin-tapi-example-demo": patch
+"@farbenmeer/vite-plugin-tapi": patch
+---
+
+vite-plugin-tapi-demo: the reference Caddyfile now sets cache headers for the client build
+
+Content-hashed assets under `/assets/*` are served with
+`Cache-Control: public, max-age=31536000, immutable`, and the SPA shell (`/`,
+`index.html`) with `no-cache`; `file_server` already emits `ETag`/`Last-Modified`
+and answers `304`. A comment documents dropping `encode` when running behind a
+compressing edge to avoid double compression, and the docker e2e test asserts
+both cache headers.
+
+Docs: the `srvx -s` static-serving note now calls out that it has no SPA history
+fallback and sets no cache headers, pointing client-routed SPAs at a static
+server / CDN (the reference Caddyfile) instead.

--- a/examples/vite-plugin-tapi-demo/Caddyfile
+++ b/examples/vite-plugin-tapi-demo/Caddyfile
@@ -7,6 +7,11 @@
 #               (single-page-app style not-found fallback)
 :80 {
 	root * /srv/client
+
+	# This demo container is served directly, so Caddy compresses responses.
+	# Behind a compressing edge / reverse proxy (e.g. Traefik, which already
+	# negotiates gzip/brotli/zstd per Accept-Encoding) drop this line so
+	# compression happens exactly once.
 	encode gzip
 
 	# API requests are handled by the srvx server.
@@ -14,7 +19,18 @@
 		reverse_proxy 127.0.0.1:{$API_PORT:3000}
 	}
 
+	# Vite emits content-hashed assets under /assets/<name>-<hash>.<ext>: the URL
+	# changes whenever the content changes, so they are safe to cache forever.
+	@assets path /assets/*
+	header @assets Cache-Control "public, max-age=31536000, immutable"
+
+	# The SPA shell is not hashed and points at the current asset URLs, so it
+	# must always be revalidated — never cache the shell itself.
+	@shell path / /index.html
+	header @shell Cache-Control "no-cache"
+
 	# Everything else: serve a static file, or fall back to index.html.
+	# file_server sets ETag/Last-Modified and answers conditional requests (304).
 	handle {
 		try_files {path} /index.html
 		file_server

--- a/examples/vite-plugin-tapi-demo/e2e/docker.spec.ts
+++ b/examples/vite-plugin-tapi-demo/e2e/docker.spec.ts
@@ -118,4 +118,19 @@ test.describe("container image (caddy + srvx)", () => {
     expect(res.status()).toBe(200);
     expect(await res.text()).toContain("vite-plugin-tapi demo");
   });
+
+  test("content-hashed assets get an immutable long-cache header", async ({
+    request,
+  }) => {
+    const html = await (await request.get("/")).text();
+    const asset = html.match(/\/assets\/[^"]+\.js/)?.[0];
+    expect(asset).toBeTruthy();
+    const res = await request.get(asset as string);
+    expect(res.headers()["cache-control"]).toContain("immutable");
+  });
+
+  test("the SPA shell is served with no-cache", async ({ request }) => {
+    const res = await request.get("/");
+    expect(res.headers()["cache-control"]).toContain("no-cache");
+  });
 });

--- a/packages/3-vite-plugin-tapi/README.md
+++ b/packages/3-vite-plugin-tapi/README.md
@@ -199,3 +199,11 @@ The path passed to `-s` is resolved **relative to the directory containing
 the entry file** (`dist/`), so `client` points at `dist/client/`.
 API routes are matched first; static files fall through when no API route
 handles the request.
+
+> **Note:** `srvx -s` serves files as-is. It has **no SPA history fallback**
+> (deep-linking or reloading a client-side route returns `404`) and sets **no
+> `Cache-Control`/`ETag`** — content-hashed assets are not marked `immutable`
+> and there is no `304` revalidation. For a client-routed SPA in production,
+> front it with a static server or CDN that handles the history fallback and
+> caching. See the reference `Caddyfile` in
+> [`examples/vite-plugin-tapi-demo`](https://github.com/farbenmeer/tapi/tree/main/examples/vite-plugin-tapi-demo).

--- a/website/src/content/docs/vite-plugin-tapi/guides/deployment.md
+++ b/website/src/content/docs/vite-plugin-tapi/guides/deployment.md
@@ -38,6 +38,10 @@ srvx --prod -s client dist/server.js
 
 The path passed to `-s` is resolved relative to the directory containing the entry file (`dist/`), so `client` points at `dist/client/`. API routes are matched first; static files fall through when no API route handles the request.
 
+:::note
+`srvx -s` serves files as-is: it has **no SPA history fallback** (deep-linking or reloading a client-side route returns `404`) and sets **no `Cache-Control`/`ETag`** (content-hashed assets are not marked `immutable`, and there is no `304` revalidation). For a client-routed SPA in production, front it with a static server or CDN that handles the history fallback and caching — see the reference `Caddyfile` in `examples/vite-plugin-tapi-demo`.
+:::
+
 ## Environment Variables
 
 The production server does not load `.env` files. Env vars must come from the runtime: Docker env, systemd `EnvironmentFile`, or your PaaS config.


### PR DESCRIPTION
## Problem

The reference `Caddyfile` in `examples/vite-plugin-tapi-demo` serves the built client with **no `Cache-Control` at all**:

- Content-hashed Vite assets (`/assets/<name>-<hash>.<ext>`) get no long-cache / `immutable`, so browsers revalidate them on every visit even though the URL changes whenever the content does.
- The SPA shell (`/`, `index.html`) is not marked `no-cache`, so a stale shell can pin old asset URLs.

The docs also oversell `srvx -s` for client-routed SPAs: it has no history fallback (deep links / reloads `404`) and sets no cache headers.

## Changes

**`Caddyfile`**
- `/assets/*` → `Cache-Control: public, max-age=31536000, immutable` (safe because Vite content-hashes these filenames).
- `/` and `index.html` → `Cache-Control: no-cache` (the shell must always revalidate).
- `file_server` already emits `ETag`/`Last-Modified` and answers `304` — no change needed there.
- Comment documenting that `encode` should be **dropped behind a compressing edge** (e.g. Traefik, which already negotiates gzip/brotli/zstd) so compression happens exactly once. The demo container is served directly, so it keeps `encode gzip`.

**`e2e/docker.spec.ts`**
- Assert `/assets/*.js` carries an `immutable` cache header and `/` is `no-cache`. (Skips automatically when no container runtime is available, like the rest of this spec.)

**Docs** (`README.md`, `website/.../deployment.md`)
- Note that `srvx -s` serves files as-is: no SPA history fallback, no `Cache-Control`/`ETag`. For a client-routed SPA in production, front it with a static server / CDN (the reference `Caddyfile`).

## Scope

Correctness/doc fixes only — no behavior change to the plugin or the tapi handler, and no change to the blessed deployment topology (srvx behind Caddy). Changeset included (`@farbenmeer/vite-plugin-tapi-example-demo` + `@farbenmeer/vite-plugin-tapi`, both patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0148BJqqcHvaUysgEemqD6DE)_