### PR TITLE
test(tag-based-cache): fix flaky redis ttl expiry test

### DIFF
--- a/.changeset/fix-redis-ttl-test-flake.md
+++ b/.changeset/fix-redis-ttl-test-flake.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix a flaky `RedisCache > expire by ttl` test that raced the TTL expiry boundary on loaded CI runners. Test-only change; no released package is affected.

--- a/packages/1-tag-based-cache/src/redis-cache.test.ts
+++ b/packages/1-tag-based-cache/src/redis-cache.test.ts
@@ -83,8 +83,9 @@ describe.skipIf(!redisAvailable)("RedisCache", () => {
       tags: [],
     });
 
-    // Wait for TTL to expire
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // Wait for TTL to expire, with margin over the 1s TTL to avoid a
+    // boundary race on loaded CI runners
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
     // Force Redis to check TTL by trying to get the key
     expect(await sut.get("test")).toEqual(null);


### PR DESCRIPTION
## Problem

CI on renovate/dependabot PRs (e.g. #401 vite bump) has been failing intermittently on a single test — `RedisCache > expire by ttl` in `packages/1-tag-based-cache/src/redis-cache.test.ts` — with no relation to the dependency being updated. The same branches fail and then pass on re-run, the signature of a flaky test.

## Root cause

The test writes a key with a **1-second** TTL (`EX: 1`), waits **exactly 1000ms**, then asserts the key has expired and returns `null`:

```ts
await sut.set({ key: "test", ttl: 1, ... });
await new Promise((resolve) => setTimeout(resolve, 1000)); // == the TTL
expect(await sut.get("test")).toEqual(null);
```

The wait equals the TTL exactly, so the GET lands right on the expiry boundary. `setTimeout` is a *minimum* delay and can fire slightly early under load, while the key's real expiry is `set_time + 1000ms` plus the SET round-trip. On a busy CI runner the GET can arrive just before Redis expires the key, the data is still present, and the assertion fails. Locally (lower load) the race is almost always won, so it "passes locally."

## Fix

Wait 1500ms to clear the 1s TTL with margin.

## Verification

Ran the redis-cache suite on the host against real Redis 4× — all 7 tests pass every time, `expire by ttl` now taking ~1507ms:

```
✓ src/redis-cache.test.ts (7 tests) 1634ms
    ✓ expire by ttl 1507ms
Tests  7 passed (7)
```

Once this merges to main, the existing renovate PRs should go green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)