### PR TITLE
ci: deploy docs independently of the npm publish result

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,9 +1,12 @@
 name: Deploy docs
 
-# Deploys the Toapi docs to GitHub Pages. Invoked by the Release workflow after
-# a changesets publish, or manually.
+# Publishes the Toapi docs to GitHub Pages when a changesets release lands on
+# main (the "Version Packages" commit), or on demand. This runs independently
+# of npm publishing, so a partial `pnpm publish` failure (e.g. packages with no
+# version change) never blocks the docs deploy.
 on:
-  workflow_call:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +21,10 @@ concurrency:
 
 jobs:
   build:
+    # Only for a changesets release commit, or a manual run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, 'Version Packages')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,11 @@ permissions:
   id-token: write # Required for OIDC
   contents: write # Required for changesets to push commits
   pull-requests: write # Required for changesets to create PRs
-  pages: write # Required to deploy the docs to GitHub Pages
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    outputs:
-      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
@@ -35,16 +32,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish
-        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-  # Publish the docs to GitHub Pages only when a release was actually published.
-  deploy-docs:
-    name: Deploy docs
-    needs: release
-    if: needs.release.outputs.published == 'true'
-    uses: ./.github/workflows/deploy-docs.yml


### PR DESCRIPTION
The docs deploy was gated on the release job's `published` output, so when `pnpm run release` failed while trying to publish packages that had no version change, the release job failed and the Pages deploy was skipped.

Decouple the two: deploy-docs is now its own workflow that runs on the changesets release commit ("Version Packages") landing on main (or via manual dispatch), so a partial npm publish failure no longer blocks the docs. Revert release.yml to a plain release job.