### PR TITLE
feat(worker): one-call setupToapiWorker + rename handleTapiRequest

### DIFF
--- a/.changeset/tapi-worker-setup.md
+++ b/.changeset/tapi-worker-setup.md
@@ -1,0 +1,7 @@
+---
+"@toapi/worker": minor
+---
+
+Add `setupToapiWorker`, a single-call helper that registers the `activate` and `fetch` listeners and opens the revalidation stream, replacing the manual `cleanup` / `handleToapiRequest` / `listenForInvalidations` wiring. The individual functions remain exported for advanced setups.
+
+Rename `handleTapiRequest` to `handleToapiRequest` as part of the tapi → toapi rebrand. `handleTapiRequest` stays as a deprecated alias for the same function and will be removed in a future major version.

--- a/packages/2-toapi-worker/src/handle-toapi-request.ts
+++ b/packages/2-toapi-worker/src/handle-toapi-request.ts
@@ -1,0 +1,54 @@
+import type { Logger } from "@toapi/common";
+import { isMutation } from "@toapi/common";
+import { getCachedEntry, getMetadata } from "./cache";
+import { mutateAndInvalidate } from "./mutate-and-invalidate";
+import { serveFromNetwork } from "./serve-from-network";
+
+export async function handleToapiRequest(
+  req: Request,
+  options?: { logger?: Logger },
+) {
+  const errorLog =
+    options?.logger?.error ??
+    ((err: unknown) => console.error("Toapi Worker fetch failed", err));
+
+  if (isMutation(req)) {
+    return mutateAndInvalidate(req);
+  } else {
+    const cachedResponse = await getCachedEntry(req);
+
+    if (!cachedResponse) {
+      // no cached response, serve from network
+      return serveFromNetwork(req);
+    }
+
+    const meta = await getMetadata(req.url);
+
+    if (meta?.expiresAt) {
+      if (meta.expiresAt > Date.now()) {
+        // cached response is still valid
+        return cachedResponse;
+      } else {
+        // cached response is expired
+        try {
+          // try to serve from network
+          return serveFromNetwork(req);
+        } catch (error) {
+          // probably network not available, serve old response
+          errorLog(error);
+          return cachedResponse;
+        }
+      }
+    }
+
+    // no expiration header, serve cached response
+    return cachedResponse;
+  }
+}
+
+/**
+ * @deprecated Renamed to {@link handleToapiRequest} as part of the tapi → toapi
+ * rebrand. This alias points to the same function and will be removed in a
+ * future major version.
+ */
+export const handleTapiRequest = handleToapiRequest;

--- a/packages/2-toapi-worker/src/index.ts
+++ b/packages/2-toapi-worker/src/index.ts
@@ -1,51 +1,7 @@
-import type { Logger } from "@toapi/common";
-import { isMutation } from "@toapi/common";
-import { getCachedEntry, getMetadata } from "./cache";
-import { mutateAndInvalidate } from "./mutate-and-invalidate";
-import { serveFromNetwork } from "./serve-from-network";
 export type { Logger } from "@toapi/common";
 export { cleanup } from "./cleanup";
 export type { CleanupOptions } from "./cleanup";
+export { handleToapiRequest, handleTapiRequest } from "./handle-toapi-request";
 export { listenForInvalidations } from "./revalidation-stream";
-
-export async function handleTapiRequest(
-  req: Request,
-  options?: { logger?: Logger },
-) {
-  const errorLog =
-    options?.logger?.error ??
-    ((err: unknown) => console.error("TApi Worker fetch failed", err));
-
-  if (isMutation(req)) {
-    return mutateAndInvalidate(req);
-  } else {
-    const cachedResponse = await getCachedEntry(req);
-
-    if (!cachedResponse) {
-      // no cached response, serve from network
-      return serveFromNetwork(req);
-    }
-
-    const meta = await getMetadata(req.url);
-
-    if (meta?.expiresAt) {
-      if (meta.expiresAt > Date.now()) {
-        // cached response is still valid
-        return cachedResponse;
-      } else {
-        // cached response is expired
-        try {
-          // try to serve from network
-          return serveFromNetwork(req);
-        } catch (error) {
-          // probably network not available, serve old response
-          errorLog(error);
-          return cachedResponse;
-        }
-      }
-    }
-
-    // no expiration header, serve cached response
-    return cachedResponse;
-  }
-}
+export { setupToapiWorker } from "./setup";
+export type { SetupToapiWorkerOptions } from "./setup";

--- a/packages/2-toapi-worker/src/setup.ts
+++ b/packages/2-toapi-worker/src/setup.ts
@@ -1,0 +1,91 @@
+import type { Logger } from "@toapi/common";
+import { INVALIDATIONS_ROUTE } from "@toapi/common";
+import { cleanup } from "./cleanup";
+import { handleToapiRequest } from "./handle-toapi-request";
+import { listenForInvalidations } from "./revalidation-stream";
+
+declare const self: ServiceWorkerGlobalScope;
+
+const ONE_WEEK_SECONDS = 60 * 60 * 24 * 7;
+
+export interface SetupToapiWorkerOptions {
+  /**
+   * Base path whose requests are handled by the Toapi cache. Same-origin
+   * requests whose pathname starts with this prefix are served from cache /
+   * network by {@link handleToapiRequest}; the `${basePath}/__tapi` control
+   * endpoints (such as the invalidation stream) are always excluded.
+   *
+   * @default "/api"
+   */
+  basePath?: string;
+  /**
+   * URL of the server's revalidation stream.
+   *
+   * @default `${basePath}/__tapi/invalidations`
+   */
+  invalidationsUrl?: string;
+  /**
+   * Grace period in seconds past a cache entry's `expiresAt` before it is
+   * dropped on the next `activate`. See {@link CleanupOptions}.
+   *
+   * @default 60 * 60 * 24 * 7 // 7 days
+   */
+  maximumStaleAge?: number;
+  /**
+   * Optional logger. Its `error` method is used for failed network refetches
+   * and for a fatal failure of the invalidation stream. Defaults to
+   * `console.error`.
+   */
+  logger?: Logger;
+}
+
+/**
+ * Wire up the whole Toapi service worker in a single call. This registers the
+ * `activate` and `fetch` listeners and opens the revalidation stream, and is
+ * equivalent to calling {@link cleanup}, {@link handleToapiRequest}, and
+ * {@link listenForInvalidations} by hand.
+ *
+ * ```ts
+ * // service-worker.ts
+ * import { setupToapiWorker } from "@toapi/worker";
+ *
+ * declare const self: ServiceWorkerGlobalScope;
+ *
+ * setupToapiWorker();
+ * ```
+ *
+ * The `fetch` listener only responds to same-origin requests under `basePath`,
+ * so it composes with other `fetch` listeners (for example
+ * `vite-plugin-pwa`'s precaching) — requests it doesn't handle fall through to
+ * them.
+ */
+export function setupToapiWorker({
+  basePath = "/api",
+  invalidationsUrl = `${basePath}${INVALIDATIONS_ROUTE}`,
+  maximumStaleAge = ONE_WEEK_SECONDS,
+  logger,
+}: SetupToapiWorkerOptions = {}) {
+  const controlPrefix = `${basePath}/__tapi`;
+  const errorLog =
+    logger?.error ??
+    ((err: unknown) =>
+      console.error("Toapi Worker: invalidation stream failed", err));
+
+  self.addEventListener("activate", (event) => {
+    event.waitUntil(cleanup({ maximumStaleAge }));
+  });
+
+  self.addEventListener("fetch", (event) => {
+    const url = new URL(event.request.url);
+    // only handle same-origin API requests, and never the control endpoints
+    if (url.origin !== self.location.origin) return;
+    if (
+      url.pathname.startsWith(basePath) &&
+      !url.pathname.startsWith(controlPrefix)
+    ) {
+      event.respondWith(handleToapiRequest(event.request, { logger }));
+    }
+  });
+
+  listenForInvalidations({ url: invalidationsUrl }).catch(errorLog);
+}

--- a/website-toapi/src/content/docs/server/reference/caching.md
+++ b/website-toapi/src/content/docs/server/reference/caching.md
@@ -63,15 +63,15 @@ The default `PubSub` implementation only works on a single host. To run Toapi ac
 
 ## Service worker cache
 
-Toapi includes tools to set up a service worker that caches Toapi responses. Create a service worker, listen to the `fetch` event, decide whether the request should be handled by Toapi, and if so call `handleTapiRequest`:
+Toapi includes tools to set up a service worker that caches Toapi responses. Create a service worker, listen to the `fetch` event, decide whether the request should be handled by Toapi, and if so call `handleToapiRequest`:
 
 ```ts
-import { handleTapiRequest } from "@toapi/worker";
+import { handleToapiRequest } from "@toapi/worker";
 
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
   if (url.host === process.env.BASE_URL && /\/api/.test(url.pathname)) {
-    event.respondWith(handleTapiRequest(event.request));
+    event.respondWith(handleToapiRequest(event.request));
   }
 });
 ```

--- a/website-toapi/src/content/docs/vite-plugin/guides/service-worker.md
+++ b/website-toapi/src/content/docs/vite-plugin/guides/service-worker.md
@@ -10,11 +10,26 @@ redirects the client build to `dist/client/`, which is exactly where VitePWA
 emits `sw.js`, and the production server bundle is built separately so nothing
 leaks across.
 
+Inside the worker the two responsibilities also compose cleanly:
+
+- **VitePWA / Workbox** precaches your **static build output** (the app shell,
+  JS, CSS, images) via the manifest it injects as `self.__WB_MANIFEST`.
+- **[`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/)** handles your
+  **Toapi API routes** — caching, offline fallback, and tag-based revalidation.
+
+Because `setupToapiWorker`'s `fetch` listener only responds to same-origin
+requests under its `basePath`, everything else — every static asset — falls
+through to Workbox's precache route. The two never fight over a request.
+
 ## Installation
 
 ```bash
-pnpm add -D vite-plugin-pwa
+pnpm add -D vite-plugin-pwa workbox-precaching
 ```
+
+`workbox-precaching` provides `precacheAndRoute`, which turns the injected
+manifest into a static-asset cache. It ships with Workbox but is a separate
+import, so install it explicitly (pnpm does not hoist transitive deps).
 
 ## Vite config
 
@@ -46,34 +61,44 @@ production.
 
 ## Service worker
 
+Precache the static build output with Workbox, then hand your API routes to
+Toapi — two calls, one file:
+
 ```ts
 // src/service-worker.ts
-import {
-  handleTapiRequest,
-  listenForInvalidations,
-  cleanup,
-} from "@toapi/worker";
+import { precacheAndRoute } from "workbox-precaching";
+import { setupToapiWorker } from "@toapi/worker";
 
-declare const self: ServiceWorkerGlobalScope;
+declare const self: ServiceWorkerGlobalScope & {
+  // VitePWA injects the precache manifest here in injectManifest mode.
+  __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
+};
 
-self.addEventListener("activate", (event) => {
-  // Drop cache entries that have been expired longer than 7 days,
-  // remove orphans, and rebuild the tags index.
-  event.waitUntil(cleanup({ maximumStaleAge: 60 * 60 * 24 * 7 }));
-});
+// 1. Cache static build files (app shell, JS, CSS, images) via VitePWA/Workbox.
+precacheAndRoute(self.__WB_MANIFEST);
 
-self.addEventListener("fetch", (event) => {
-  const url = new URL(event.request.url);
-  if (
-    url.pathname.startsWith("/api") &&
-    !url.pathname.startsWith("/api/__tapi")
-  ) {
-    event.respondWith(handleTapiRequest(event.request));
-  }
-});
-
-listenForInvalidations({ url: "/api/__tapi/invalidations" });
+// 2. Cache & revalidate Toapi API routes.
+setupToapiWorker();
 ```
+
+`precacheAndRoute(self.__WB_MANIFEST)` registers a `fetch` route for every
+static file VitePWA fingerprinted at build time, so navigations and assets work
+offline. `setupToapiWorker()` adds its own `fetch` listener that only claims
+same-origin requests under `/api` (skipping `/api/__tapi`), so the two coexist:
+static requests are served from the precache, API requests from the Toapi cache.
+
+If your API lives somewhere other than `/api`, pass a matching `basePath` — and
+make sure it isn't a prefix VitePWA also precaches:
+
+```ts
+setupToapiWorker({ basePath: "/data" });
+```
+
+:::note
+`self.__WB_MANIFEST` **must** appear literally in the source — it's the
+injection point VitePWA replaces with the real manifest. If you remove it the
+build fails.
+:::
 
 ## TypeScript
 
@@ -90,10 +115,17 @@ recognizes `ServiceWorkerGlobalScope` and related globals:
 
 ## Notes
 
-- Adjust the `/api` path checks in the service worker to match the `basePath`
-  you pass to `toapi()`.
-- `cleanup`'s `maximumStaleAge` is a grace period, in seconds, past a cache
-  entry's `expiresAt` before it is actually deleted on the next SW activation.
+- Match `setupToapiWorker`'s `basePath` to the `basePath` you pass to `toapi()`.
+  It defaults to `/api`.
+- Pass `maximumStaleAge` to `setupToapiWorker` to tune the grace period, in
+  seconds, past a cache entry's `expiresAt` before it is deleted on the next SW
+  activation. It defaults to 7 days.
+- Need to interleave your own `activate`/`fetch` logic with Toapi's? Call
+  [`cleanup`](/tapi/worker/reference/cleanup/),
+  [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/), and
+  [`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/)
+  directly instead of `setupToapiWorker`.
 
 For the full service-worker API, see the
+[`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/) reference and the
 [`@toapi/worker`](/tapi/worker/) package.

--- a/website-toapi/src/content/docs/worker/guides/service-worker.md
+++ b/website-toapi/src/content/docs/worker/guides/service-worker.md
@@ -9,12 +9,47 @@ register it on your page.
 ## 1. Create the Service Worker
 
 Create a `service-worker.ts` file in your project (e.g. at the root or in
-`src/`):
+`src/`) and call [`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/):
+
+```ts
+// service-worker.ts
+import { setupToapiWorker } from "@toapi/worker";
+
+declare const self: ServiceWorkerGlobalScope;
+
+setupToapiWorker();
+```
+
+That single call registers the `activate` and `fetch` listeners and opens
+the revalidation stream. By default it caches same-origin requests under
+`/api` (excluding the `/api/__tapi` control endpoints) and listens for
+invalidations on `/api/__tapi/invalidations`. Pass options to adjust the
+base path, stream URL, stale window, or logger:
+
+```ts
+setupToapiWorker({
+  basePath: "/data",
+  maximumStaleAge: 60 * 60 * 24, // 1 day
+});
+```
+
+When the service worker connects to the invalidation stream, it
+automatically marks every cached entry as expired so the next access
+revalidates it. On each `activate` it also runs a cleanup pass that bounds
+long-term cache growth: entries whose `expiresAt` is older than
+`maximumStaleAge` seconds are deleted, cache entries that no longer have a
+meta record are removed, and the tags index is rebuilt from the surviving
+meta records.
+
+### Wiring it up by hand
+
+If you need to interleave Toapi with your own `activate`/`fetch` logic,
+call the underlying functions directly instead of `setupToapiWorker`:
 
 ```ts
 // service-worker.ts
 import {
-  handleTapiRequest,
+  handleToapiRequest,
   listenForInvalidations,
   cleanup,
 } from "@toapi/worker";
@@ -33,7 +68,7 @@ self.addEventListener("fetch", (event) => {
     url.pathname.startsWith("/api") &&
     !url.pathname.startsWith("/api/__tapi")
   ) {
-    event.respondWith(handleTapiRequest(event.request));
+    event.respondWith(handleToapiRequest(event.request));
   }
 });
 
@@ -42,14 +77,6 @@ listenForInvalidations({ url: "/api/__tapi/invalidations" });
 
 Adjust the pathname checks to match your API base path and revalidation
 endpoint.
-
-When the service worker connects to the invalidation stream, it
-automatically marks every cached entry as expired so the next access
-revalidates it. `cleanup({ maximumStaleAge })` is what you call from the
-`activate` event to bound long-term cache growth: it deletes entries
-whose `expiresAt` is older than `maximumStaleAge` seconds, removes any
-cache entries that no longer have a meta record, and rebuilds the tags
-index from the surviving meta records.
 
 ## 2. Add TypeScript Types
 
@@ -140,6 +167,7 @@ revalidation stream.
 
 ## Related
 
-- [`handleTapiRequest`](/tapi/worker/reference/handle-tapi-request/)
+- [`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/)
+- [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/)
 - [`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/)
 - [`cleanup`](/tapi/worker/reference/cleanup/)

--- a/website-toapi/src/content/docs/worker/index.md
+++ b/website-toapi/src/content/docs/worker/index.md
@@ -31,47 +31,53 @@ setup and the full build/register recipe.
 
 | Export | Kind | Purpose |
 | --- | --- | --- |
-| [`handleTapiRequest`](/tapi/worker/reference/handle-tapi-request/) | function | Handle a single `fetch` event: serve from cache, network, or invalidate on mutation. |
+| [`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/) | function | Set up the whole worker in one call: registers the listeners and opens the stream. |
+| [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/) | function | Handle a single `fetch` event: serve from cache, network, or invalidate on mutation. |
 | [`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/) | function | Open the server's revalidation stream and apply remote tag invalidations. |
 | [`cleanup`](/tapi/worker/reference/cleanup/) | function | Reconcile the cache and metadata stores, typically from the `activate` event. |
+| `SetupToapiWorkerOptions` | type | Options for [`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/). |
 | `CleanupOptions` | type | Options for [`cleanup`](/tapi/worker/reference/cleanup/). |
-| `Logger` | type | Re-exported from `@toapi/common`; the optional logger accepted by `handleTapiRequest`. |
+| `Logger` | type | Re-exported from `@toapi/common`; the optional logger accepted by `handleToapiRequest`. |
 
 ## Minimal service worker
 
+The whole worker is a single call:
+
 ```ts
 // service-worker.ts
-import {
-  handleTapiRequest,
-  listenForInvalidations,
-  cleanup,
-} from "@toapi/worker";
+import { setupToapiWorker } from "@toapi/worker";
 
 declare const self: ServiceWorkerGlobalScope;
 
-self.addEventListener("activate", (event) => {
-  event.waitUntil(cleanup({ maximumStaleAge: 60 * 60 * 24 * 7 }));
-});
+setupToapiWorker();
+```
 
-self.addEventListener("fetch", (event) => {
-  const url = new URL(event.request.url);
-  if (
-    url.pathname.startsWith("/api") &&
-    !url.pathname.startsWith("/api/__tapi")
-  ) {
-    event.respondWith(handleTapiRequest(event.request));
-  }
-});
+By default this caches same-origin requests under `/api` (excluding the
+`/api/__tapi` control endpoints) and listens for invalidations on
+`/api/__tapi/invalidations`. Pass options to change the base path, stream URL,
+stale window, or logger:
 
-listenForInvalidations({ url: "/api/__tapi/invalidations" });
+```ts
+setupToapiWorker({
+  basePath: "/data",
+  maximumStaleAge: 60 * 60 * 24, // 1 day
+});
 ```
 
 :::note
-`@toapi/worker` only manages requests you route to it. The `fetch` listener
-above deliberately handles requests under `/api` while excluding the
-`/api/__tapi` control endpoints (such as the invalidation stream). Adjust
-those checks to match your API base path.
+`setupToapiWorker`'s `fetch` listener only responds to same-origin requests
+under `basePath`, so everything else falls through to any other `fetch`
+listeners — that's how it composes with `vite-plugin-pwa`'s static-asset
+precaching. See the
+[vite-plugin service-worker guide](/tapi/vite-plugin/guides/service-worker/).
 :::
+
+If you need to interleave Toapi with your own `activate`/`fetch` logic, you can
+wire up [`cleanup`](/tapi/worker/reference/cleanup/),
+[`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/), and
+[`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/) by
+hand instead — see the
+[service-worker guide](/tapi/worker/guides/service-worker/).
 
 ## Related
 

--- a/website-toapi/src/content/docs/worker/reference/cleanup.md
+++ b/website-toapi/src/content/docs/worker/reference/cleanup.md
@@ -68,6 +68,6 @@ because the Cache API is async and would otherwise auto-commit it.
 
 ## Related
 
-- [`handleTapiRequest`](/tapi/worker/reference/handle-tapi-request/)
+- [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/)
 - [`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/)
 - [Service worker setup guide](/tapi/worker/guides/service-worker/)

--- a/website-toapi/src/content/docs/worker/reference/handle-toapi-request.md
+++ b/website-toapi/src/content/docs/worker/reference/handle-toapi-request.md
@@ -1,17 +1,24 @@
 ---
-title: "handleTapiRequest"
+title: "handleToapiRequest"
 description: "Handle a single service-worker fetch event: serve from cache, revalidate from network, or invalidate on mutation."
 ---
 
-`handleTapiRequest` is the core request handler for the Toapi service worker.
+`handleToapiRequest` is the core request handler for the Toapi service worker.
 Pass it the `Request` from a `fetch` event and it decides whether to serve from
 Cache Storage, fetch from the network, or run a mutation and invalidate the
 affected tags.
 
+:::note[Renamed]
+This function was previously called `handleTapiRequest`. That name is still
+exported as a deprecated alias for the same function and will be removed in a
+future major version — prefer `handleToapiRequest`. Most setups don't call it
+directly at all; use [`setupToapiWorker`](/tapi/worker/reference/setup-toapi-worker/).
+:::
+
 ## Signature
 
 ```ts
-function handleTapiRequest(
+function handleToapiRequest(
   req: Request,
   options?: { logger?: Logger },
 ): Promise<Response>;
@@ -28,7 +35,7 @@ Returns a `Promise<Response>` suitable for passing to `event.respondWith(...)`.
 ## Usage
 
 ```ts
-import { handleTapiRequest } from "@toapi/worker";
+import { handleToapiRequest } from "@toapi/worker";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -38,7 +45,7 @@ self.addEventListener("fetch", (event) => {
     url.pathname.startsWith("/api") &&
     !url.pathname.startsWith("/api/__tapi")
   ) {
-    event.respondWith(handleTapiRequest(event.request));
+    event.respondWith(handleToapiRequest(event.request));
   }
 });
 ```
@@ -92,13 +99,13 @@ interface Logger {
 into your own reporting rather than `console.error`:
 
 ```ts
-import { handleTapiRequest, type Logger } from "@toapi/worker";
+import { handleToapiRequest, type Logger } from "@toapi/worker";
 
 const logger: Logger = {
   error: (err) => reportToSentry(err),
 };
 
-handleTapiRequest(event.request, { logger });
+handleToapiRequest(event.request, { logger });
 ```
 
 ## Related

--- a/website-toapi/src/content/docs/worker/reference/listen-for-invalidations.md
+++ b/website-toapi/src/content/docs/worker/reference/listen-for-invalidations.md
@@ -60,7 +60,7 @@ offline) nothing stale is served without first checking the network.
 Expiring on connect means the first read of each cached resource after the
 worker (re)connects will revalidate against the network. Entries are not
 deleted — if the network is unavailable, the expired entry is still served by
-[`handleTapiRequest`](/tapi/worker/reference/handle-tapi-request/).
+[`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/).
 :::
 
 ### Streaming invalidations
@@ -85,6 +85,6 @@ unless you are building a custom client integration.
 
 ## Related
 
-- [`handleTapiRequest`](/tapi/worker/reference/handle-tapi-request/)
+- [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/)
 - [`cleanup`](/tapi/worker/reference/cleanup/)
 - [Service worker setup guide](/tapi/worker/guides/service-worker/)

--- a/website-toapi/src/content/docs/worker/reference/setup-toapi-worker.md
+++ b/website-toapi/src/content/docs/worker/reference/setup-toapi-worker.md
@@ -1,0 +1,110 @@
+---
+title: "setupToapiWorker"
+description: "Wire up the whole Toapi service worker — cleanup, request handling, and the revalidation stream — in a single call."
+---
+
+`setupToapiWorker` is the one-call way to set up a Toapi service worker. It
+registers the `activate` and `fetch` listeners and opens the revalidation
+stream, so you don't have to wire up [`cleanup`](/tapi/worker/reference/cleanup/),
+[`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/), and
+[`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/)
+yourself.
+
+## Signature
+
+```ts
+function setupToapiWorker(options?: SetupToapiWorkerOptions): void;
+
+interface SetupToapiWorkerOptions {
+  /** Base path whose requests are cached. Default: "/api". */
+  basePath?: string;
+  /** Revalidation stream URL. Default: `${basePath}/__tapi/invalidations`. */
+  invalidationsUrl?: string;
+  /** Grace period in seconds past expiry before cleanup drops an entry. Default: 7 days. */
+  maximumStaleAge?: number;
+  /** Optional logger for failed refetches and a fatal stream failure. Default: `console.error`. */
+  logger?: Logger;
+}
+```
+
+- **`basePath`** — same-origin requests whose pathname starts with this prefix
+  are routed through [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/).
+  The `${basePath}/__tapi` control endpoints (the invalidation stream, the
+  OpenAPI document) are always excluded. Defaults to `"/api"`.
+- **`invalidationsUrl`** — the URL of the server's revalidation stream. Defaults
+  to `${basePath}/__tapi/invalidations`.
+- **`maximumStaleAge`** — how many seconds an entry may remain past its
+  `expiresAt` before [`cleanup`](/tapi/worker/reference/cleanup/) drops it on the
+  next `activate`. Defaults to 7 days.
+- **`logger`** — an optional [`Logger`](/tapi/worker/reference/handle-toapi-request/#logger).
+
+## Usage
+
+```ts
+// service-worker.ts
+import { setupToapiWorker } from "@toapi/worker";
+
+declare const self: ServiceWorkerGlobalScope;
+
+setupToapiWorker();
+```
+
+With a custom base path and stale window:
+
+```ts
+setupToapiWorker({
+  basePath: "/data",
+  maximumStaleAge: 60 * 60 * 24, // 1 day
+});
+```
+
+## Composing with other `fetch` listeners
+
+`setupToapiWorker` adds a `fetch` listener that only calls `respondWith` for
+same-origin requests under `basePath`. Every other request falls through to any
+other `fetch` listeners you (or another plugin) have registered. That is what
+makes it compose with `vite-plugin-pwa`'s static-asset precaching: Toapi handles
+the API routes, VitePWA/Workbox handles the app shell and static files. See the
+[vite-plugin service-worker guide](/tapi/vite-plugin/guides/service-worker/) for
+the full recipe.
+
+## Equivalent manual setup
+
+`setupToapiWorker()` is exactly equivalent to:
+
+```ts
+import {
+  cleanup,
+  handleToapiRequest,
+  listenForInvalidations,
+} from "@toapi/worker";
+
+declare const self: ServiceWorkerGlobalScope;
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(cleanup({ maximumStaleAge: 60 * 60 * 24 * 7 }));
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
+  if (
+    url.pathname.startsWith("/api") &&
+    !url.pathname.startsWith("/api/__tapi")
+  ) {
+    event.respondWith(handleToapiRequest(event.request));
+  }
+});
+
+listenForInvalidations({ url: "/api/__tapi/invalidations" });
+```
+
+Reach for the individual functions when you need to interleave Toapi with your
+own `activate`/`fetch` logic; otherwise prefer `setupToapiWorker`.
+
+## Related
+
+- [`handleToapiRequest`](/tapi/worker/reference/handle-toapi-request/)
+- [`listenForInvalidations`](/tapi/worker/reference/listen-for-invalidations/)
+- [`cleanup`](/tapi/worker/reference/cleanup/)
+- [Service worker setup guide](/tapi/worker/guides/service-worker/)


### PR DESCRIPTION
## Summary

Simplifies `@toapi/worker` setup to a single function call and aligns the public API with the tapi → toapi rebrand.

- **`setupToapiWorker`** — new one-call setup that registers the `activate` and `fetch` listeners and opens the revalidation stream, replacing the manual `cleanup` / `handleToapiRequest` / `listenForInvalidations` wiring. Its `fetch` listener only claims same-origin requests under `basePath` (excluding the `/__tapi` control endpoints), so it composes with other `fetch` listeners such as `vite-plugin-pwa`'s precaching. Options: `basePath`, `invalidationsUrl`, `maximumStaleAge`, `logger`.
- **`handleTapiRequest` → `handleToapiRequest`** — renamed for the toapi branding, following the same deprecate-and-alias pattern as the recent `delete` → `invalidate` change. `handleTapiRequest` remains exported as a `@deprecated` alias to the same function, so existing importers keep working (non-breaking).
- The individual functions (`cleanup`, `handleToapiRequest`, `listenForInvalidations`) remain exported for advanced setups that interleave their own `activate`/`fetch` logic.

Left untouched per scope: the `/__tapi` wire-protocol paths (shared with `@toapi/server`), the `tapi-cache` storage names, and internal log prefixes.

## Docs

- Worker and vite-plugin guides now lead with the single `setupToapiWorker()` call, with the manual wiring kept as a fallback section.
- **New dedicated vite-pwa recipe**: Workbox precaches the static build output via `precacheAndRoute(self.__WB_MANIFEST)` while `setupToapiWorker()` handles the Toapi API routes, with an explanation of why the two `fetch` listeners compose.
- Renamed the reference pages (`handle-tapi-request` → `handle-toapi-request`, added `setup-toapi-worker`) and updated all cross-links; added a "Renamed" note documenting the deprecated alias.

## Verification

- `@toapi/worker` typechecks/builds (`tsc`).
- Docs site builds cleanly (58 pages, new slugs generated, no broken links).

## Changeset

`minor` bump for `@toapi/worker` covering the new helper and the rename + deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)