### PR TITLE
Move Observable type to @toapi/common, drop react peer dep on client

### DIFF
--- a/.changeset/observable-to-common.md
+++ b/.changeset/observable-to-common.md
@@ -1,0 +1,7 @@
+---
+"@toapi/common": minor
+"@toapi/client": minor
+"@toapi/react": minor
+---
+
+Move the `Observable` type from `@toapi/client` to `@toapi/common`. `@toapi/client` continues to re-export `Observable`, so its public API is unchanged. `@toapi/react` now depends on `@toapi/common` directly and no longer has a peer dependency on `@toapi/client`.

--- a/packages/1-toapi-common/src/index.ts
+++ b/packages/1-toapi-common/src/index.ts
@@ -3,6 +3,7 @@ export * from "./http-error.js";
 export * from "./is-mutation.js";
 export type * from "./logger.js";
 export type * from "./maybe-promise.js";
+export type * from "./observable.js";
 export type * from "./path.js";
 export type * from "./route.js";
 export type * from "./handler.js";

--- a/packages/1-toapi-common/src/observable.ts
+++ b/packages/1-toapi-common/src/observable.ts
@@ -1,0 +1,3 @@
+export type Observable<T> = {
+  subscribe(callback: (value: Promise<T>) => void): () => void;
+};

--- a/packages/2-toapi-client/src/cache.ts
+++ b/packages/2-toapi-client/src/cache.ts
@@ -1,6 +1,5 @@
 import { EXPIRES_AT_HEADER, TAGS_HEADER } from "@toapi/common";
-import type { Logger } from "@toapi/common";
-import type { Observable } from "./client-types.js";
+import type { Logger, Observable } from "@toapi/common";
 import { handleResponse } from "./handle-response.js";
 
 type ObservablePromise = Promise<unknown> & Observable<unknown>;

--- a/packages/2-toapi-client/src/client-types.ts
+++ b/packages/2-toapi-client/src/client-types.ts
@@ -3,6 +3,7 @@ import type {
   Path as BasePath,
   BaseRoute,
   MaybePromise,
+  Observable,
 } from "@toapi/common";
 
 type Segment<Path> = Path extends `/${infer Segment}/${string}`
@@ -55,10 +56,6 @@ export type QueryWithoutBody<
         query: OptionalizeUndefined<QueryType<Handler>>,
         req?: RequestInit,
       ) => Promise<ResponseType<Handler>> & Observable<ResponseType<Handler>>;
-
-export type Observable<T> = {
-  subscribe(callback: (value: Promise<T>) => void): () => void;
-};
 
 export type Revalidating = {
   revalidated: Promise<void>;

--- a/packages/2-toapi-client/src/index.ts
+++ b/packages/2-toapi-client/src/index.ts
@@ -1,5 +1,5 @@
 export { HttpError, INVALIDATIONS_ROUTE } from "@toapi/common";
-export type { Logger } from "@toapi/common";
-export type { Client, Observable } from "./client-types.js";
+export type { Logger, Observable } from "@toapi/common";
+export type { Client } from "./client-types.js";
 export { createFetchClient } from "./create-fetch-client.js";
 export type { GetRoute, PostRoute } from "./route-types.js";

--- a/packages/2-toapi-client/src/route-types.ts
+++ b/packages/2-toapi-client/src/route-types.ts
@@ -1,4 +1,4 @@
-import type { Observable } from "./client-types.js";
+import type { Observable } from "@toapi/common";
 
 export type GetRoute<R, Q = undefined> = Q extends undefined
   ? (query?: {}, req?: RequestInit) => Promise<R> & Observable<R>

--- a/packages/2-toapi-react/package.json
+++ b/packages/2-toapi-react/package.json
@@ -22,6 +22,9 @@
     "release": "pnpm run build && pnpm publish --no-git-checks",
     "test": "vitest"
   },
+  "dependencies": {
+    "@toapi/common": "workspace:^"
+  },
   "devDependencies": {
     "@toapi/client": "workspace:^",
     "@toapi/server": "workspace:^",
@@ -36,7 +39,6 @@
     "zod": "^4.1.5"
   },
   "peerDependencies": {
-    "@toapi/client": "workspace:^",
     "react": "^19.1.1",
     "typescript": "^5 || ^6.0.0"
   }

--- a/packages/2-toapi-react/src/use-query.ts
+++ b/packages/2-toapi-react/src/use-query.ts
@@ -1,4 +1,4 @@
-import type { Observable } from "@toapi/client";
+import type { Observable } from "@toapi/common";
 import * as React from "react";
 
 type ObservablePromise<T> = Promise<T> & Observable<T>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
 
   packages/2-toapi-react:
     dependencies:
+      '@toapi/common':
+        specifier: workspace:^
+        version: link:../1-toapi-common
       typescript:
         specifier: ^5 || ^6.0.0
         version: 6.0.3


### PR DESCRIPTION
## Summary

`@toapi/react` was related to `@toapi/client` only through the `Observable` type used by `useQuery`. This moves that type into `@toapi/common` so react can depend on common directly and drop its peer dependency on client.

## Changes

- **`@toapi/common`**: add `Observable<T>` (new `src/observable.ts`) and re-export it from the package index.
- **`@toapi/client`**: import `Observable` from `@toapi/common` in `client-types.ts`, `route-types.ts`, and `cache.ts`; remove the local declaration. The client index continues to re-export `Observable`, so the client's public API is unchanged.
- **`@toapi/react`**: `use-query.ts` now imports `Observable` from `@toapi/common`; add `@toapi/common` as a direct dependency and remove `@toapi/client` from `peerDependencies` (`@toapi/client` remains a devDependency used by the tests).
- Added a changeset (minor for common, client, react).

## Verification

- `@toapi/common`, `@toapi/client`, and `@toapi/react` all build clean (`tsc`).
- `@toapi/react` tests pass (5/5); `@toapi/common` tests pass (32/32).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHareNqMr1S7JB5JdiweoA)_